### PR TITLE
Better support updating between versions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -200,6 +200,15 @@ $ oc process -f metrics.yaml -v \
      HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com,USE_PERSISTENT_STORAGE=false,REDEPLOY=true \
      | oc create -n openshift-infra -f -
 ----
+
+The `REDEPLOY` option used to also delete all the persistent volume claims (pvc) and as such all presisted data would be lost when using this option. With the more recent versions
+`REDEPLOY` will not delete the pvc.
+
+To manually delete the pvc you can run the following command:
+
+----
+$ oc delete pvc --selector="metrics-infra"
+----
 ====
 
 == Verifying the Components after Installation

--- a/README.adoc
+++ b/README.adoc
@@ -192,18 +192,25 @@ $ oc process -f metrics.yaml -v \
 
 [NOTE]
 ====
-If you ever wish to undeploy and then redeploy all the metric components, you can do so with the `REDEPLOY` template parameter. Note that this will also remove any persistent volume claims and any persisted data will be lost.
+If you ever wish to undeploy and then redeploy all the metric components, you can do so by setting the `MODE` template parameter to 'redeploy'. Note that this will also remove any persistent volume claims and any persisted data will be lost.
 Any non persisted data will be lost as well. This is equivalent to deleting all the components and then restarting everything overagain.
 
 For example:
 ----
 $ oc process -f metrics.yaml -v \
-     HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com,USE_PERSISTENT_STORAGE=false,REDEPLOY=true \
+     HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com,USE_PERSISTENT_STORAGE=false,MODE=redeploy \
      | oc create -n openshift-infra -f -
 ----
 
-The `REFRESH` option performs the same steps as the `REDEPLOY` option but the persistent volume claims and route will not be deleted. Any non-persisted data will be lost with this operation. This option is useful if you wish
+The `refresh` value for `MODE` performs the same steps as 'redeploy' but the persistent volume claims and route will not be deleted. Any non-persisted data will be lost with this operation. This option is useful if you wish
 to redeploy your components with updated deployer secrets or if you wish to deploy another newer version.
+
+For example:
+----
+$ oc process -f metrics.yaml -v \
+     HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com,USE_PERSISTENT_STORAGE=false,MODE=refresh \
+     | oc create -n openshift-infra -f -
+----
 
 To manually delete the pvc and route, you can run the following command:
 

--- a/README.adoc
+++ b/README.adoc
@@ -192,7 +192,8 @@ $ oc process -f metrics.yaml -v \
 
 [NOTE]
 ====
-If you ever wish to undeploy and then redeploy all the metric components, you can do so with the `REDEPLOY` template parameter.
+If you ever wish to undeploy and then redeploy all the metric components, you can do so with the `REDEPLOY` template parameter. Note that this will also remove any persistent volume claims and any persisted data will be lost.
+Any non persisted data will be lost as well. This is equivalent to deleting all the components and then restarting everything overagain.
 
 For example:
 ----
@@ -201,13 +202,14 @@ $ oc process -f metrics.yaml -v \
      | oc create -n openshift-infra -f -
 ----
 
-The `REDEPLOY` option used to also delete all the persistent volume claims (pvc) and as such all presisted data would be lost when using this option. With the more recent versions
-`REDEPLOY` will not delete the pvc.
+The `REFRESH` option performs the same steps as the `REDEPLOY` option but the persistent volume claims and route will not be deleted. Any non-persisted data will be lost with this operation. This option is useful if you wish
+to redeploy your components with updated deployer secrets or if you wish to deploy another newer version.
 
-To manually delete the pvc you can run the following command:
+To manually delete the pvc and route, you can run the following command:
 
 ----
 $ oc delete pvc --selector="metrics-infra"
+$ oc delete route --selector="metrics-infra"
 ----
 ====
 

--- a/deployer/run-hawkular.sh
+++ b/deployer/run-hawkular.sh
@@ -190,7 +190,7 @@ oc create -f templates/support.yaml
 echo "Deploying Hawkular Metrics & Cassandra Components"
 oc process hawkular-metrics -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,METRIC_DURATION=$metric_duration,MASTER_URL=$master_url" | oc create -f -
 oc process hawkular-cassandra-services | oc create -f -
-oc process hawkular-support -v "HAWKULAR_METRICS_HOSTNAME=$hawkular_metrics_hostname" | oc create -f -
+oc process hawkular-support -v "HAWKULAR_METRICS_HOSTNAME=$hawkular_metrics_hostname" | oc create -f - || true
 
 if [ "${use_persistent_storage}" = true ]; then
   echo "Setting up Cassandra with Persistent Storage"

--- a/deployer/run-hawkular.sh
+++ b/deployer/run-hawkular.sh
@@ -195,11 +195,13 @@ oc process hawkular-support -v "HAWKULAR_METRICS_HOSTNAME=$hawkular_metrics_host
 if [ "${use_persistent_storage}" = true ]; then
   echo "Setting up Cassandra with Persistent Storage"
   # Deploy the main 'master' Cassandra node
-  oc process hawkular-cassandra-node-pv -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,NODE=1,PV_SIZE=$cassandra_pv_size,MASTER=true" | oc create -f -
+  # Note that this may return an error code if the pvc already exists, this is to be expected and why we have the || true here
+  oc process hawkular-cassandra-node-pv -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,NODE=1,PV_SIZE=$cassandra_pv_size,MASTER=true" | oc create -f -  || true
   # Deploy any subsequent Cassandra nodes
   for i in $(seq 2 $cassandra_nodes);
   do
-    oc process hawkular-cassandra-node-pv -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,PV_SIZE=$cassandra_pv_size,NODE=$i" | oc create -f -
+    # Note that this may return an error code if the pvc already exists, this is to be expected and why we have the || true here
+    oc process hawkular-cassandra-node-pv -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,PV_SIZE=$cassandra_pv_size,NODE=$i" | oc create -f - || true
   done
 else 
   echo "Setting up Cassandra with Non Persistent Storage"

--- a/deployer/run.sh
+++ b/deployer/run.sh
@@ -114,9 +114,6 @@ if [ "$redeploy" = true  ]; then
 
   echo "Deleting the secrets"
   oc delete secrets --selector="metrics-infra"
-
-  echo "Deleting any pvc"
-  oc delete pvc --selector="metrics-infra"
 fi
 
 if [ -z "${HEAPSTER_STANDALONE}" ]; then 

--- a/deployer/run.sh
+++ b/deployer/run.sh
@@ -26,6 +26,7 @@ master_url=${MASTER_URL:-https://kubernetes.default.svc:8443}
 
 # Set to true to undeploy everything before deploying
 redeploy=${REDEPLOY:-false}
+refresh=${REFRESH:-false}
 
 # The number of initial Cassandra Nodes to Deploy
 cassandra_nodes=${CASSANDRA_NODES:-1}
@@ -103,6 +104,7 @@ if [ -n "${WRITE_KUBECONFIG}" ]; then
 fi
 
 if [ "$redeploy" = true  ]; then
+  
   echo "Deleting any previous deployment"
   oc delete all --selector="metrics-infra"
 
@@ -114,6 +116,26 @@ if [ "$redeploy" = true  ]; then
 
   echo "Deleting the secrets"
   oc delete secrets --selector="metrics-infra"
+
+  echo "Deleting any pvc"		
+  oc delete pvc --selector="metrics-infra"
+
+elif [ "$refresh" = true ]; then
+
+  echo "Deleting any previous deployment"
+  oc delete rc --selector="metrics-infra"
+  oc delete svc --selector="metrics-infra"
+  oc delete pod --selector="metrics-infra" 
+
+  echo "Deleting any exisiting service account"
+  oc delete sa --selector="metrics-infra"
+
+  echo "Deleting the templates"
+  oc delete templates --selector="metrics-infra"
+
+  echo "Deleting the secrets"
+  oc delete secrets --selector="metrics-infra"
+
 fi
 
 if [ -z "${HEAPSTER_STANDALONE}" ]; then 

--- a/deployer/run.sh
+++ b/deployer/run.sh
@@ -26,7 +26,7 @@ master_url=${MASTER_URL:-https://kubernetes.default.svc:8443}
 
 # Set to true to undeploy everything before deploying
 redeploy=${REDEPLOY:-false}
-refresh=${REFRESH:-false}
+mode=${MODE:-deploy}
 
 # The number of initial Cassandra Nodes to Deploy
 cassandra_nodes=${CASSANDRA_NODES:-1}
@@ -103,7 +103,7 @@ if [ -n "${WRITE_KUBECONFIG}" ]; then
     oc config use-context current
 fi
 
-if [ "$redeploy" = true  ]; then
+if [ "$redeploy" = true  ] || [ "$mode" = "redeploy" ]; then
   
   echo "Deleting any previous deployment"
   oc delete all --selector="metrics-infra"
@@ -120,7 +120,7 @@ if [ "$redeploy" = true  ]; then
   echo "Deleting any pvc"		
   oc delete pvc --selector="metrics-infra"
 
-elif [ "$refresh" = true ]; then
+elif [ "$mode" = "refresh" ]; then
 
   echo "Deleting any previous deployment"
   oc delete rc --selector="metrics-infra"

--- a/deployer/templates/heapster.yaml
+++ b/deployer/templates/heapster.yaml
@@ -74,7 +74,7 @@ objects:
           - "--wrapper.allowed_users_file=/secrets/heapster.allowed-users"
           - "--wrapper.endpoint_check=https://hawkular-metrics:443/hawkular/metrics/status"
           - "--source=kubernetes:${MASTER_URL}?useServiceAccount=true&kubeletHttps=true&kubeletPort=10250"
-          - "--sink=hawkular:https://hawkular-metrics:443?tenant=_system&labelToTenant=pod_namespace&caCert=/hawkular-cert/hawkular-metrics-ca.certificate&user=%username%&pass=%password%&filter=label(container_name:^/system.slice.*|^/user.slice)"
+          - "--sink=hawkular:https://hawkular-metrics:443?tenant=_system&labelToTenant=pod_namespace&caCert=/hawkular-cert/hawkular-metrics-ca.certificate&user=%username%&pass=%password%&filter=label(container_name:^system.slice.*|^user.slice)"
           - "--tls_cert=/secrets/heapster.cert"
           - "--tls_key=/secrets/heapster.key"
           - "--tls_client_ca=/secrets/heapster.client-ca"

--- a/docs/deployer_configuration.adoc
+++ b/docs/deployer_configuration.adoc
@@ -83,10 +83,17 @@ Default: *"https://kubernetes.default.svc:443"*
 |:white_check_mark:
 
 |*_REDEPLOY_*
-|If set to true the deployer will try and delete all the existing components before trying to redeploy.
+|If set to true the deployer will delete and redeloy all the existing metrics components. All persisted and non-persisted data will be lost.
 
 Default: *"false"*
 |
+
+|*_REFRESH_*
+|If set to true the deployer will delete and redeploy all exisiting metrics components expect the persistent volume claims and route. Persisted data will remain available but all non-persisted data will be lost.
+
+Default: *"false"*
+|
+
 
 |*_USE_PERSISTENT_STORAGE_*
 |Set to true for persistent storage, set to false to use non persistent storage

--- a/docs/deployer_configuration.adoc
+++ b/docs/deployer_configuration.adoc
@@ -88,10 +88,13 @@ Default: *"https://kubernetes.default.svc:443"*
 Default: *"false"*
 |
 
-|*_REFRESH_*
-|If set to true the deployer will delete and redeploy all exisiting metrics components expect the persistent volume claims and route. Persisted data will remain available but all non-persisted data will be lost.
+|*_MODE_*
+|Can be used to set the deployment options.
+`deploy` is to be used to perform the initial install
+`refresh` will delete and redeploy all exisiting metrics components except the persistent volume claims and route. Persisted data will remain available but all non-persisted data will be lost.
+`redeploy` will delete and redeploy all existing metric components. All persisted and non-persisted data will be lost.
 
-Default: *"false"*
+Default: *"deploy"*
 |
 
 

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -56,8 +56,8 @@ objects:
           value: ${MASTER_URL}
         - name: REDEPLOY
           value: ${REDEPLOY}
-        - name: REFRESH
-          value: ${REFRESH}
+        - name: MODE
+          value: ${MODE}
         - name: USE_PERSISTENT_STORAGE
           value: ${USE_PERSISTENT_STORAGE}
         - name: HAWKULAR_METRICS_HOSTNAME
@@ -99,9 +99,9 @@ parameters:
   name: REDEPLOY
   value: "false"
 -
-  description: "If set to true the deployer will delete and redeploy all exisiting metrics components expect the persistent volume claims and route. Persisted data will remain available but all non-persisted data will be lost."
-  name: REFRESH
-  value: "false"
+  description: "Can be set to: 'deploy' to perform an initial deployment; 'refresh' to delete and redeploy all components but to keep persisted data and routes; 'redeploy' to delete and redeploy everything (losing all data in the process)"
+  name: MODE
+  value: "deploy"
 -
   description: "Set to true for persistent storage, set to false to use non persistent storage"
   name: USE_PERSISTENT_STORAGE

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -56,6 +56,8 @@ objects:
           value: ${MASTER_URL}
         - name: REDEPLOY
           value: ${REDEPLOY}
+        - name: REFRESH
+          value: ${REFRESH}
         - name: USE_PERSISTENT_STORAGE
           value: ${USE_PERSISTENT_STORAGE}
         - name: HAWKULAR_METRICS_HOSTNAME
@@ -93,8 +95,12 @@ parameters:
   name: HAWKULAR_METRICS_HOSTNAME
   required: true
 -
-  description: "If set to true the deployer will try and delete all the existing components before trying to redeploy."
+  description: "If set to true the deployer will delete and redeloy all the existing metrics components. All persisted and non-persisted data will be lost."
   name: REDEPLOY
+  value: "false"
+-
+  description: "If set to true the deployer will delete and redeploy all exisiting metrics components expect the persistent volume claims and route. Persisted data will remain available but all non-persisted data will be lost."
+  name: REFRESH
   value: "false"
 -
   description: "Set to true for persistent storage, set to false to use non persistent storage"


### PR DESCRIPTION
The following patch helps us to better support updating between versions. The `REDEPLOY` option has been modified to no longer delete the pvc and now when it is used we can update all the templates, refresh the certificates (eg in case of expiry) and redeploy all the components. Since the pvc is no longer deleted, all the persisted data will continue to be available.

Since Heapster, Hawkular Metrics and Cassandra are being redeployed during this time, there will be a gap in the metrics while this is occurring.

Ideally we should seamlessly be able to update without a gap in the metrics, but I am unsure how exactly that can be accomplished. There are a lot of components which may be required to be updated between versions and it would get tricky to try and update things as they are all running.

I was going to go in and create a new deployment option here ('update', 'refresh', ?) but I think for now modifying the `REDEPLOY` option might be the better option. We do need a better way to handle this in the future though.
