### PR TITLE
Remove the heapster base image from the main build.

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -66,7 +66,7 @@ if [ "$verbose" = true ]; then
   set -x
 fi
 
-for component in deployer heapster-base heapster hawkular-metrics cassandra; do
+for component in deployer heapster hawkular-metrics cassandra; do
   BUILD_STARTTIME=$(date +%s)
   comp_path=$source_root/$component/
   docker_tag=${prefix}metrics-${component}:${version}


### PR DESCRIPTION
The Heapster base image is meant to just contain the Heapster binary that our normal Heapster image uses. It's currently being tagged with the Heapster version, not the origin-metrics version (see https://github.com/openshift/origin-metrics/blob/master/heapster/Dockerfile#L19).

I don't know if we really want to add this to our main build or not.  We should only be updating this version when a new version of Heapster is released or a patch that we need is merged into Heapster upstream. If we could have gotten away with only using proper Heapster releases, then we could potentially even remove the base image and just download the binary directly.

Any thoughts on this? I would prefer to remove it from the automated build script if possible, how its being done today is wrong in the version it's tagged with is never used.