### PR TITLE
Fix an NFSv3 locking issue

### DIFF
--- a/deployer/scripts/functions.sh
+++ b/deployer/scripts/functions.sh
@@ -33,7 +33,8 @@ function handle_previous_deployment() {
     oc delete rc,svc,pod,sa,templates,secrets --selector="metrics-infra"
   elif [ "$redeploy" = true ] || [ "$mode" = remove ]; then
     echo "Deleting any previous deployment"
-    oc delete all,sa,templates,secrets,pvc --selector="metrics-infra"
+    oc delete --grace-period=0 all,sa,templates,secrets --selector="metrics-infra"
+    oc delete pvc --selector="metrics-infra"
   fi
 }
 


### PR DESCRIPTION
Changing the re-deploy to terminate and remove pods immediately by adding --grace-period=0 is more in line with what a REDEPLOY not marked as "refresh" should do. Remove everything that is currently there and not allow the system to leave lingering pods/etc, which currently happens.

This also removes a race condition with NFSv3 PVs which basically fail to get recycled due to the fact that some pods have files open still at the same time as the recycler tries to go in and recycle, but fails due to the fact that there are open files and NFS creates locks, which then break the recycler. Separating the two processes out, eliminates the race condition and should introduce anything "new" just stage the process a bit better than an all in one swoop.