### PR TITLE
Fix issue where the deployer will kill itself before it finishes

### DIFF
--- a/metrics.yaml
+++ b/metrics.yaml
@@ -48,6 +48,10 @@ objects:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: IMAGE_PREFIX
           value: ${IMAGE_PREFIX}
         - name: IMAGE_VERSION


### PR DESCRIPTION
This fixes an issue where the deployer will terminate itself before it finishes being deployed.

Now the deployer will not be removed automatically when the 'redeploy' option is used (which it probably shouldn't have been anyways, since it can hide the fact that it terminated in an error state). But the deployer will still remove old deployer instances when the 'redeploy' option is used (to remove all instances that don't need to be kept around)