### PR TITLE
Remove 'docker.io/' from the docker image when performing a build.

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -7,7 +7,7 @@ set -o pipefail
 STARTTIME=$(date +%s)
 source_root=$(dirname "${0}")/..
 
-prefix="docker.io/openshift/origin-"
+prefix="openshift/origin-"
 version="latest"
 verbose=false
 options=""


### PR DESCRIPTION
 Fixes an issue where local images cannot be used since the deployer image would always be fetched from docker.io