### PR TITLE
Add support for dynamically provisioning volumes

### DIFF
--- a/deployer/run.sh
+++ b/deployer/run.sh
@@ -47,6 +47,8 @@ fi
 cassandra_nodes=${CASSANDRA_NODES:-1}
 # If we should use persistent storage or not
 use_persistent_storage=${USE_PERSISTENT_STORAGE:-true}
+# If we should dynamically provision storage
+dynamically_provision_storage=${DYNAMICALLY_PROVISION_STORAGE:-false}
 # The size of each Cassandra Node
 cassandra_pv_size=${CASSANDRA_PV_SIZE:-10Gi}
 

--- a/deployer/scripts/hawkular.sh
+++ b/deployer/scripts/hawkular.sh
@@ -185,6 +185,7 @@ EOF
   oc create -f templates/hawkular-metrics.yaml
   oc create -f templates/hawkular-cassandra.yaml
   oc create -f templates/hawkular-cassandra-node-pv.yaml
+  oc create -f templates/hawkular-cassandra-node-dynamic-pv.yaml
   oc create -f templates/hawkular-cassandra-node-emptydir.yaml
   oc create -f templates/support.yaml
   
@@ -194,16 +195,29 @@ EOF
   oc process hawkular-support -v "HAWKULAR_METRICS_HOSTNAME=$hawkular_metrics_hostname" | oc create -f - || true
   
   if [ "${use_persistent_storage}" = true ]; then
-    echo "Setting up Cassandra with Persistent Storage"
-    # Deploy the main 'master' Cassandra node
-    # Note that this may return an error code if the pvc already exists, this is to be expected and why we have the || true here
-    oc process hawkular-cassandra-node-pv -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,NODE=1,PV_SIZE=$cassandra_pv_size,MASTER=true" | oc create -f - || true
-    # Deploy any subsequent Cassandra nodes
-    for i in $(seq 2 $cassandra_nodes);
-    do
+    if [ "${dynamically_provision_storage}" = true ]; then
+      echo "Setting up Cassandra with Dynamically Provisioned Storage"
+      # Deploy the main 'master' Cassandra node
       # Note that this may return an error code if the pvc already exists, this is to be expected and why we have the || true here
-      oc process hawkular-cassandra-node-pv -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,PV_SIZE=$cassandra_pv_size,NODE=$i" | oc create -f - || true
-    done
+      oc process hawkular-cassandra-node-dynamic-pv -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,NODE=1,PV_SIZE=$cassandra_pv_size,MASTER=true" | oc create -f - || true
+      # Deploy any subsequent Cassandra nodes
+      for i in $(seq 2 $cassandra_nodes);
+      do
+        # Note that this may return an error code if the pvc already exists, this is to be expected and why we have the || true here
+        oc process hawkular-cassandra-node-dynamic-pv -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,PV_SIZE=$cassandra_pv_size,NODE=$i" | oc create -f - || true
+      done
+    else
+      echo "Setting up Cassandra with Persistent Storage"
+      # Deploy the main 'master' Cassandra node
+      # Note that this may return an error code if the pvc already exists, this is to be expected and why we have the || true here
+      oc process hawkular-cassandra-node-pv -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,NODE=1,PV_SIZE=$cassandra_pv_size,MASTER=true" | oc create -f - || true
+      # Deploy any subsequent Cassandra nodes
+      for i in $(seq 2 $cassandra_nodes);
+      do
+        # Note that this may return an error code if the pvc already exists, this is to be expected and why we have the || true here
+        oc process hawkular-cassandra-node-pv -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,PV_SIZE=$cassandra_pv_size,NODE=$i" | oc create -f - || true
+      done
+    fi
   else 
     echo "Setting up Cassandra with Non Persistent Storage"
     oc process hawkular-cassandra-node-emptydir -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,NODE=1,MASTER=true" | oc create -f -  

--- a/deployer/scripts/validate.sh
+++ b/deployer/scripts/validate.sh
@@ -147,7 +147,7 @@ function test_deployed_pvcs() {
     local template='{{range .items}}{{println .metadata.name " " .status.phase}}{{end}}'
     # check that the PVCs exist and are bound; if not, retry briefly before failing
     local i line output unbound=()
-    for i in 1 2 3 4 5; do
+    for ((i=0; i<=60; i++)); do
       if ! output=$(check_exists persistentvolumeclaim --selector=metrics-infra=hawkular-cassandra --template="$template"); then
         echo -e "$output"
         echo "The metrics deployment requires a PVC for each Cassandra pod and will not run."

--- a/deployer/templates/hawkular-cassandra-node-dynamic-pv.yaml
+++ b/deployer/templates/hawkular-cassandra-node-dynamic-pv.yaml
@@ -1,0 +1,114 @@
+id: hawkular-cassandra-node-dynamic-pv
+kind: Template
+apiVersion: v1
+name: 'Hawkular Cassandra Node Template: Persistent Storage'
+description: Configures a Cassandra Node to be added to a cluster.
+metadata:
+  name: hawkular-cassandra-node-dynamic-pv
+  labels:
+    metrics-infra: hawkular-cassandra
+parameters:
+- description: Specify prefix for metrics components; e.g. for "openshift/origin-metrics-deployer:v1.1",
+    set prefix "openshift/origin-"
+  name: IMAGE_PREFIX
+  value: openshift/origin-
+- description: Specify version for metrics components; e.g. for "openshift/origin-metrics-deployer:v1.1",
+    set version "v1.1"
+  name: IMAGE_VERSION
+  value: "latest"
+- description: If this Cassandra node should be the 'master' node.
+  name: MASTER
+  value: 'false'
+- description: The persistent volume claim prefix.
+  name: PV_PREFIX
+  value: metrics-cassandra
+- description: The node number for the Cassandra cluster.
+  name: NODE
+  required: true
+- description: The size of storage requested.
+  name: PV_SIZE
+  value: 10Gi
+objects:
+- kind: PersistentVolumeClaim
+  apiVersion: v1
+  metadata:
+    name: "${PV_PREFIX}-${NODE}"
+    labels:
+      metrics-infra: hawkular-cassandra
+    annotations:
+      volume.alpha.kubernetes.io/storage-class: "foo"
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: "${PV_SIZE}"
+- apiVersion: v1
+  kind: ReplicationController
+  metadata:
+    name: hawkular-cassandra-${NODE}
+    labels:
+      metrics-infra: hawkular-cassandra
+      name: hawkular-cassandra
+      type: hawkular-cassandra
+  spec:
+    selector:
+      name: hawkular-cassandra-${NODE}
+    replicas: 1
+    template:
+      version: v1
+      metadata:
+        labels:
+          metrics-infra: hawkular-cassandra
+          name: hawkular-cassandra-${NODE}
+          type: hawkular-cassandra
+      spec:
+        serviceAccount: cassandra
+        containers:
+        - image: "${IMAGE_PREFIX}metrics-cassandra:${IMAGE_VERSION}"
+          name: hawkular-cassandra-${NODE}
+          ports:
+          - name: cql-port
+            containerPort: 9042
+          - name: thift-port
+            containerPort: 9160
+          - name: tcp-port
+            containerPort: 7000
+          - name: ssl-port
+            containerPort: 7001
+          command:
+          - "/opt/apache-cassandra/bin/cassandra-docker.sh"
+          - "--cluster_name=hawkular-metrics"
+          - "--data_volume=/cassandra_data"
+          - "--internode_encryption=all"
+          - "--require_node_auth=true"
+          - "--enable_client_encryption=true"
+          - "--require_client_auth=true"
+          - "--keystore_file=/secret/cassandra.keystore"
+          - "--keystore_password_file=/secret/cassandra.keystore.password"
+          - "--truststore_file=/secret/cassandra.truststore"
+          - "--truststore_password_file=/secret/cassandra.truststore.password"
+          - "--cassandra_pem_file=/secret/cassandra.pem"
+          env:
+          - name: CASSANDRA_MASTER
+            value: "${MASTER}"
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          volumeMounts:
+          - name: cassandra-data
+            mountPath: "/cassandra_data"
+          - name: hawkular-cassandra-secrets
+            mountPath: "/secret"
+          readinessProbe:
+            exec:
+              command:
+              - "/opt/apache-cassandra/bin/cassandra-docker-ready.sh"
+        volumes:
+        - name: cassandra-data
+          persistentVolumeClaim:
+            claimName: "${PV_PREFIX}-${NODE}"
+        - name: hawkular-cassandra-secrets
+          secret:
+            secretName: hawkular-cassandra-secrets

--- a/deployer/templates/hawkular-cassandra-node-dynamic-pv.yaml
+++ b/deployer/templates/hawkular-cassandra-node-dynamic-pv.yaml
@@ -36,7 +36,7 @@ objects:
     labels:
       metrics-infra: hawkular-cassandra
     annotations:
-      volume.alpha.kubernetes.io/storage-class: "foo"
+      volume.alpha.kubernetes.io/storage-class: "dynamic"
   spec:
     accessModes:
     - ReadWriteOnce

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -62,6 +62,8 @@ objects:
           value: ${IGNORE_PREFLIGHT}
         - name: USE_PERSISTENT_STORAGE
           value: ${USE_PERSISTENT_STORAGE}
+        - name: DYNAMICALLY_PROVISION_STORAGE
+          value: ${DYNAMICALLY_PROVISION_STORAGE}
         - name: HAWKULAR_METRICS_HOSTNAME
           value: ${HAWKULAR_METRICS_HOSTNAME}
         - name: CASSANDRA_NODES
@@ -116,6 +118,10 @@ parameters:
   description: "Set to true for persistent storage, set to false to use non persistent storage"
   name: USE_PERSISTENT_STORAGE
   value: "true"
+-
+  description: "Set to true to dynamically provision storage, set to false to use use pre-created persistent volumes"
+  name: DYNAMICALLY_PROVISION_STORAGE
+  value: "false"
 -
   description: "The number of Cassandra Nodes to deploy for the initial cluster"
   name: CASSANDRA_NODES


### PR DESCRIPTION
Really rough first pass at adding support for dynamically provisioned volumes on top of the v1.2.0 tag.

Resolves https://github.com/openshift/origin-metrics/issues/137