### PR TITLE
deployer: improve validation event handling

### DIFF
--- a/hack/tests/ci_test_every_pr.sh
+++ b/hack/tests/ci_test_every_pr.sh
@@ -34,14 +34,12 @@ DEBUG_FAILURES=${DEBUG_FAILURES:-false}
 USE_LOCAL_SOURCE=${USE_LOCAL_SOURCE:-false}
 TEST_PERF=${TEST_PERF:-false}
 
-# includes util.sh and text.sh
-source "${OS_ROOT}/hack/cmd_util.sh"
-source "${OS_ROOT}/hack/lib/test/junit.sh"
-source "${OS_ROOT}/hack/common.sh"
-source "${OS_ROOT}/hack/lib/log.sh"
+# include all the origin test libs we need
+for lib in "${OS_ROOT}"/hack/{util.sh,text.sh} \
+           "${OS_ROOT}"/hack/lib/*.sh "${OS_ROOT}"/hack/lib/**/*.sh
+do source "$lib"; done
 os::log::install_errexit
 
-source "${OS_ROOT}/hack/lib/util/environment.sh"
 os::util::environment::setup_time_vars
 
 cd "${OS_ROOT}"

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -34,9 +34,11 @@ objects:
   metadata:
     generateName: metrics-deployer-
   spec:
+    securityContext: {}
     containers:
     - image: ${IMAGE_PREFIX}metrics-deployer:${IMAGE_VERSION}
       name: deployer
+      securityContext: {}
       volumeMounts:
       - name: secret
         mountPath: /secret


### PR DESCRIPTION
Updated validations to look at Scheduled events as an antidote to
SchedulingFailed events and give the failures a second chance to be
resolved. This should address the case where a PVC is dynamically bound,
the pod having received a SchedulingFailed in the meantime.

Also, redeploy / refresh no longer attempt to modify the deployer pod
label as this does not seem to be allowed by the server any longer. As a
consequence they also don't attempt to delete previous deployer pods.