### PR TITLE
e2e: improve argument parsing

### DIFF
--- a/hack/README.adoc
+++ b/hack/README.adoc
@@ -47,6 +47,9 @@ The following table outlines the various options which can be used to change thi
 |--skipTests
 |Sets up the system but does not run any of the tests. Useful when testing one specific test
 
+|--test name
+|Executes only the tests named `name`.
+
 |--debug
 |Outputs debugging information about what the tests is currently doing.
 

--- a/hack/README.adoc
+++ b/hack/README.adoc
@@ -41,14 +41,14 @@ The following table outlines the various options which can be used to change thi
 |--cacheBuild
 |Use the Docker cache when building the docker images
 
+|--selector s
+|Use the node selector `s` when creating the projects the tests run on
+
 |--continue
 |Leaves the project running after the tests have finished. Useful for debugging purposes as to why a test is failing
 
 |--skipTests
 |Sets up the system but does not run any of the tests. Useful when testing one specific test
-
-|--test name
-|Executes only the tests named `name`.
 
 |--debug
 |Outputs debugging information about what the tests is currently doing.
@@ -63,6 +63,38 @@ For example, if you don't want to build new docker images for the tests and want
 ----
 $ e2e-tests.sh --skipBuild --continue
 ----
+
+The `debug`, `continue`, `x`, and the following flags are also passed to each
+test:
+
+[cols="2,4",options="header"]
+|===
+
+|Option |Description
+
+|--heapster_template t
+|Use the file `t` as the template to deploy heapster.  Default:
+`metrics-heapster.yaml`.
+
+|--image_prefix p
+|Add the prefix `p` to the name of the images (see `docs/build.adoc`).
+Default: `openshift/origin-`.
+
+|--image_version v
+|Use the image version `v` (see `docs/build.adoc`).  Default: `latest`.
+
+|--template t
+|Use the file `t` as the template to deploy the metrics components.  Default:
+`metrics.yaml`.
+
+|--test name
+|Executes only the tests named `name`.
+
+|--timeout t
+|Maximum number of seconds an operation can take during the tests before it is
+considered failed.  Default: `180`.
+
+|===
 
 === Running a single test
 

--- a/hack/e2e-tests.sh
+++ b/hack/e2e-tests.sh
@@ -5,19 +5,26 @@ source $SOURCE_ROOT/hack/tests/common.sh
 
 parse_args() {
   local tmp long
-  long=cacheBuild,continue,selector:,skipBuild,skipTests,test:
+  long=cacheBuild,continue,selector:,skipBuild,skipTests
+  # flags forwarded to the tests
+  long=$long,debug,heapster_template:,image_prefix:,image_version:,template:
+  long=$long,test:,timeout:
   tmp=$(getopt --options x --long "$long" --name "$(basename "$0")" -- "$@") \
     || return 1
   eval set -- "$tmp"
   while :; do
     case "$1" in
       --cacheBuild) buildOpts=; shift;;
-      --continue) continue=true; shift;;
       --selector) NODE_SELECTOR=$2; shift 2;;
       --skipBuild) build=false; shift;;
       --skipTests) skipTests=true; shift;;
-      --test) test=$2; shift 2;;
-      -x) set_x=-x; set -x; shift;;
+      --continue) continue=true; test_args+=("$1"); shift;;
+      -x) set_x=true; test_args+=("$1"); shift;;
+      --debug) test_args+=("$1"); shift;;
+      --heapster_template|--image_prefix|--image_version|--template|--test)
+        test_args+=("$1" "$2"); shift 2;;
+      --timeout)
+        test_args+=("$1" "$2"); shift 2;;
       --) shift; break;;
     esac
   done
@@ -27,10 +34,11 @@ continue=
 build=true
 skipTests=false
 buildOpts=--no-cache
-test=
 set_x=
+test_args=()
 
 parse_args "$@" || exit
+[ "$set_x" ] && set -x
 
 Info $SEPARATOR
 Info "Starting Origin-Metric end-to-end test"
@@ -108,7 +116,6 @@ test.setup
 #Run the tests
 if [ "$skipTests" = false ]; then
   for x in default_deploy standalone_docker heapster; do
-    "$SOURCE_ROOT/hack/tests/test_$x.sh" \
-      $set_x ${test:+--test "$test"} ${continue:+--continue}
+    "$SOURCE_ROOT/hack/tests/test_$x.sh" "${test_args[@]}"
   done
 fi

--- a/hack/tests/base.sh
+++ b/hack/tests/base.sh
@@ -104,18 +104,39 @@ function runTest {
   Info
 }
 
+parse_args() {
+  local tmp long
+  long=continue,debug,heapster_template:,image_prefix:,image_version:,template:
+  long=$long,test:,timeout:
+  tmp=$(getopt --options x --long "$long" --name "$(basename "$0")" -- "$@") \
+    || return 1
+  eval set -- "$tmp"
+  while :; do
+    case "$1" in
+      --continue) continue=true; shift;;
+      --debug) debug=true; shift;;
+      --heapster_template) heapster_template=$2; shift 2;;
+      --image_prefix) image_prefix=$2; shift 2;;
+      --image_version) image_version=$2; shift 2;;
+      --template) template=$2; shift 2;;
+      --test) test=$2; shift 2;;
+      --timeout) timeout=$2; shift 2;;
+      -x) set -x; shift;;
+      --) shift; break;;
+    esac
+  done
+}
+
 continue=false
-for args in "$@"
-do
-  case $args in
-    --test=*)
-      test="${args#*=}"
-      ;;
-    --continue)
-      continue=true
-      ;;
-  esac
-done
+debug=false
+timeout=180
+template=$SOURCE_ROOT/metrics.yaml
+heapster_template=$SOURCE_ROOT/metrics-heapster.yaml
+image_prefix=openshift/origin-
+image_version=latest
+test=
+
+parse_args "$@" || exit
 
 if [[ -z ${TEST_PROJECT:-} ]]; then
   export TEST_PROJECT=`oc project --short`

--- a/hack/tests/common.sh
+++ b/hack/tests/common.sh
@@ -18,36 +18,6 @@ green=`tput setaf 2 || true`
 orange=`tput setaf 166 || true`
 reset=`tput sgr0 || true`
 
-debug=${debug:-false}
-timeout=${timeout:-180}
-template=${template:-$SOURCE_ROOT/metrics.yaml}
-heapster_template=${heapster_tempalte:-$SOURCE_ROOT/metrics-heapster.yaml}
-image_prefix=${image_prefix:-openshift/origin-}
-image_version=${image_version:-latest}
-for args in "$@"
-do
-  case $args in
-    --debug)
-      debug=true
-      ;;
-    --timeout=*)
-      timeout="${args#*=}"
-      ;;
-    --template=*)
-      template="${args#*=}"
-      ;;
-    --heapster_template=*)
-      heapster_template="${args#*=}"
-      ;;
-    --image_prefix=*)
-      image_prefix="${args#*=}"
-      ;;
-    --image_version=*)
-      image_version="${args#*=}"
-      ;;
-  esac
-done
-
 function Error {
   echo ${red}[ERROR] $@${reset}
 }


### PR DESCRIPTION
- use `getopt(1)` to validate flag names and number of arguments
- centralize parsing so it happens in only one place (for each script)