### PR TITLE
Add Hawkular-Metrics client

### DIFF
--- a/deployer/scripts/hawkular.sh
+++ b/deployer/scripts/hawkular.sh
@@ -65,7 +65,7 @@ function deploy_hawkular() {
   
   hawkular_metrics_password=`cat /dev/urandom | tr -dc _A-Z-a-z-0-9 | head -c15`
   htpasswd -cb $dir/hawkular-metrics.htpasswd hawkular $hawkular_metrics_password 
-  
+
   echo
   echo "Creating the Hawkular Metrics Secrets configuration json file"
   cat > $dir/hawkular-metrics-secrets.json <<EOF
@@ -89,7 +89,7 @@ function deploy_hawkular() {
         }
       }
 EOF
-  
+
   echo
   echo "Creating the Hawkular Metrics Certificate Secrets configuration json file"
   cat > $dir/hawkular-metrics-certificate.json <<EOF
@@ -109,7 +109,7 @@ EOF
         }
       }
 EOF
-  
+
   echo
   echo "Creating the Hawkular Metrics User Account Secrets"
   cat > $dir/hawkular-metrics-account.json <<EOF

--- a/deployer/templates/hawkular-metrics.yaml
+++ b/deployer/templates/hawkular-metrics.yaml
@@ -89,6 +89,8 @@ objects:
           volumeMounts:
           - name: hawkular-metrics-secrets
             mountPath: "/secrets"
+          - name: hawkular-metrics-client-secrets
+            mountPath: "/client-secrets"
           readinessProbe:
             exec:
               command:
@@ -101,3 +103,6 @@ objects:
         - name: hawkular-metrics-secrets
           secret:
             secretName: hawkular-metrics-secrets
+        - name: hawkular-metrics-client-secrets
+          secret:
+            secretName: hawkular-metrics-account

--- a/hawkular-metrics/Dockerfile
+++ b/hawkular-metrics/Dockerfile
@@ -32,6 +32,8 @@ ENV HAWKULAR_METRICS_ENDPOINT_PORT="8080" \
     HAWKULAR_METRICS_DIRECTORY="/opt/hawkular" \
     HAWKULAR_METRICS_SCRIPT_DIRECTORY="/opt/hawkular/scripts/"
 
+ENV PATH=$PATH:$HAWKULAR_METRICS_SCRIPT_DIRECTORY
+
 # The http and https ports
 EXPOSE 8080 8444
 
@@ -49,6 +51,8 @@ RUN curl -Lo $JBOSS_HOME/bin/alpn-boot-$ALPN_VERSION.jar http://central.maven.or
 COPY hawkular-metrics-readiness.py \
      hawkular-metrics-liveness.py \
      hawkular-metrics-wrapper.sh \
+     hawkular-client-initialization.py \
+     client \
      $HAWKULAR_METRICS_SCRIPT_DIRECTORY
 
 # Overwrite the welcome-content to display a more appropriate status page
@@ -59,6 +63,14 @@ COPY standalone.xml $JBOSS_HOME/standalone/configuration/standalone.xml
 
 # Overwrite the default logging.properties file
 COPY logging.properties $JBOSS_HOME/standalone/configuration/logging.properties
+
+# Install Hawkular-Metrics Python client, only available on EPEL
+USER root
+RUN yum -y install epel-release
+RUN yum -y install python-pip; yum clean all
+RUN pip install 'hawkular-client==0.4.4'
+#RUN pip install hawkular-client
+USER 1000
 
 # Change the permissions so that the user running the image can start up Hawkular Metrics
 USER root

--- a/hawkular-metrics/client
+++ b/hawkular-metrics/client
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#PYTHONSTARTUP=hawkular-client-initialization.py
+python -i $HAWKULAR_METRICS_SCRIPT_DIRECTORY/hawkular-client-initialization.py

--- a/hawkular-metrics/hawkular-client-initialization.py
+++ b/hawkular-metrics/hawkular-client-initialization.py
@@ -1,0 +1,27 @@
+#!/bin/python
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+from hawkular import *
+
+hwkpass = open('/client-secrets/hawkular-metrics.password').read().rstrip()
+hwkuser = open('/client-secrets/hawkular-metrics.username').read().rstrip()
+
+hawkularEndpointPort = os.environ.get("HAWKULAR_METRICS_ENDPOINT_PORT")
+
+c = HawkularMetricsClient(tenant_id='default', username=hwkuser, password=hwkpass, port=hawkularEndpointPort)


### PR DESCRIPTION
This PR adds a pre-initialized Python client to the Hawkular-Metrics pod, for easier debugging and access.

To start it, enter ``client`` in the bash prompt. The client is under variable ``c`` and documentation can be found from [](https://github.com/hawkular/hawkular-client-python )

Resolves #115 