### PR TITLE
Add logging debug file to container.

### DIFF
--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -54,6 +54,7 @@ RUN cd /opt; \
 # Copy our version of the cassandra configuration file over to the filesystem
 COPY cassandra.yaml.template \
      cassandra-env.sh.template \
+     cassandra-metrics-reporter.yaml \
      /opt/apache-cassandra/conf/
 
 # Copy across the scripts

--- a/cassandra/cassandra-metrics-reporter.yaml
+++ b/cassandra/cassandra-metrics-reporter.yaml
@@ -1,0 +1,17 @@
+console:
+  -
+    period: 10
+    timeunit: 'SECONDS'
+    predicate:
+      color: "white"
+      useQualifiedName: true
+      patterns:
+        - "^org.apache.cassandra.metrics.Cache.+"
+        - "^org.apache.cassandra.metrics.ClientRequest.+" # includes ClientRequestMetrics
+        - "^org.apache.cassandra.metrics.CommitLog.+"
+        - "^org.apache.cassandra.metrics.Compaction.+"
+        - "^org.apache.cassandra.metrics.DroppedMetrics.+"
+        - "^org.apache.cassandra.metrics.ReadRepair.+"
+        - "^org.apache.cassandra.metrics.Storage.+"
+        - "^org.apache.cassandra.metrics.ThreadPools.+"
+


### PR DESCRIPTION
Adds a logging configuration file to the container which, if enabled, can be used to produce Cassandra debugging logs.

To enable this debugging log, you just need to set an env value for the container.

```
        - name: JVM_EXTRA_OPTS
          value: -Dcassandra.metricsReporterConfigFile=cassandra-metrics-reporter.yaml
```

This is only meant for more debugging cases which get a bit tricky, such as issues with the filesystem not being able to keep up with rights.

Its also possible to add this in manually by creating a confmap, loading the file as a volume, and setting the env var, but this gets a bit more tricky.