### PR TITLE
Run Hawkular Metrics in a 'master' mode.

### DIFF
--- a/deployer/scripts/hawkular.sh
+++ b/deployer/scripts/hawkular.sh
@@ -185,6 +185,7 @@ EOF
   
   echo "Creating Hawkular Metrics & Cassandra Templates"
   oc create -f templates/hawkular-metrics.yaml
+  oc create -f templates/hawkular-metrics-service.yaml
   oc create -f templates/hawkular-cassandra.yaml
   oc create -f templates/hawkular-cassandra-node-pv.yaml
   oc create -f templates/hawkular-cassandra-node-dynamic-pv.yaml
@@ -192,7 +193,9 @@ EOF
   oc create -f templates/support.yaml
 
   echo "Deploying Hawkular Metrics & Cassandra Components"
-  oc process hawkular-metrics -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,METRIC_DURATION=$metric_duration,MASTER_URL=$master_url,USER_WRITE_ACCESS=$user_write_access" | oc create -f -
+  oc process hawkular-metrics -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,METRIC_DURATION=$metric_duration,MASTER_URL=$master_url,USER_WRITE_ACCESS=$user_write_access,HAWKULAR_METRICS_MASTER=true,HAWKULAR_METRICS_REPLICATION_CONTROLLER_NAME=hawkular-master" | oc create -f -
+  oc process hawkular-metrics -v "IMAGE_PREFIX=$image_prefix,IMAGE_VERSION=$image_version,METRIC_DURATION=$metric_duration,MASTER_URL=$master_url,USER_WRITE_ACCESS=$user_write_access,REPLICAS=0" | oc create -f -
+  oc process hawkular-metrics-service | oc create -f -
   oc process hawkular-cassandra-services | oc create -f -
   oc process hawkular-support | oc create -f -
 

--- a/deployer/templates/hawkular-metrics-service.yaml
+++ b/deployer/templates/hawkular-metrics-service.yaml
@@ -1,0 +1,24 @@
+id: hawkular-metrics-service
+kind: Template
+apiVersion: v1
+name: Hawkular Metrics Template
+description: A template to created a Hawkular Metrics instance.
+metadata:
+  name: hawkular-metrics-service
+  labels:
+    metrics-infra: hawkular-metrics-service
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: hawkular-metrics
+    labels:
+      metrics-infra: hawkular-metrics
+      name: hawkular-metrics
+  spec:
+    selector:
+      name: hawkular-metrics
+    ports:
+    - name: https-endpoint
+      port: 443
+      targetPort: https-endpoint

--- a/deployer/templates/hawkular-metrics.yaml
+++ b/deployer/templates/hawkular-metrics.yaml
@@ -25,38 +25,35 @@ parameters:
 - description: If users accounts should be able to write metrics
   name: USER_WRITE_ACCESS
   value: "false"
+- description: If this should be considered a 'master' Hawkular Metrics instance
+  name: HAWKULAR_METRICS_MASTER
+  value: "false"
+- description: The name of the replication controller
+  name: HAWKULAR_METRICS_REPLICATION_CONTROLLER_NAME
+  value: hawkular-metrics
+- description: The number of initial replicas
+  name: REPLICAS
+  value: "1"
 objects:
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: hawkular-metrics
-    labels:
-      metrics-infra: hawkular-metrics
-      name: hawkular-metrics
-  spec:
-    selector:
-      name: hawkular-metrics
-    ports:
-    - name: https-endpoint
-      port: 443
-      targetPort: https-endpoint
 - apiVersion: v1
   kind: ReplicationController
   metadata:
-    name: hawkular-metrics
+    name: ${HAWKULAR_METRICS_REPLICATION_CONTROLLER_NAME}
     labels:
       metrics-infra: hawkular-metrics
       name: hawkular-metrics
   spec:
     selector:
       name: hawkular-metrics
-    replicas: 1
+      hawkular-metrics-master: ${HAWKULAR_METRICS_MASTER}
+    replicas: ${REPLICAS}
     template:
       version: v1
       metadata:
         labels:
           metrics-infra: hawkular-metrics
           name: hawkular-metrics
+          hawkular-metrics-master: ${HAWKULAR_METRICS_MASTER}
       spec:
         serviceAccount: hawkular
         containers:
@@ -104,6 +101,10 @@ objects:
                 fieldPath: metadata.namespace
           - name: OPENSHIFT_KUBE_PING_LABELS
             value: "metrics-infra=hawkular-metrics,name=hawkular-metrics"
+          - name: MASTER_URL
+            value: ${MASTER_URL}
+          - name: HAWKULAR_METRICS_MASTER
+            value: ${HAWKULAR_METRICS_MASTER}
           volumeMounts:
           - name: hawkular-metrics-secrets
             mountPath: "/secrets"


### PR DESCRIPTION
There is an issue where if two Hawkular Metrics instance start at the same time, they can both try and update the schema in Cassandra which can run into problems requiring manual intervention.

This pr runs a new rc which runs a special 'master' Hawkular Metrics which is only allowed to run as one instance. If the rc is set to run above 1, then it will not start and output an error message to change it back to one.

The existing Hawkular Metrics cluster is set to 0 in this case by default and can be increased normally as required.

This PR is not ready to be merged, as the validation scripts in the deployer will fail because the normal Hawkular Metrics RC is set to 0.

Is there a better way to handle this? Its kindof more messy than what I would have liked. But as far as I can tell, there is really no other way to handle this in a better fashion.
