### PR TITLE
Check that Hawkular has the required permissions for clustering.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -105,6 +105,19 @@ $ oadm policy add-role-to-user edit \
         -n openshift-infra
 ----
 
+=== Hawkular Service Account
+
+The hawkular service account requires `view` permissions in order to gather information about pods that will make up a Hawkular Metrics cluster.
+
+Run the following command to add the `view` permission to the `hawkular` service account:
+
+----
+$ oadm policy add-role-to-user view \
+        system:serviceaccount:openshift-infra:hawkular \
+        -n openshift-infra
+----
+
+
 === Heapster Service Account
 
 The heapster component requires accessing the kubernetes node to find all the available nodes as well as accessing the `/stats` endpoint on each of those nodes. This means that the `heapster` service account which requires having the `cluster-reader` permission.

--- a/deployer/templates/hawkular-metrics.yaml
+++ b/deployer/templates/hawkular-metrics.yaml
@@ -98,6 +98,8 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: MASTER_URL
+            value: ${MASTER_URL}
           - name: OPENSHIFT_KUBE_PING_NAMESPACE
             valueFrom:
               fieldRef:

--- a/hack/tests/test_default_deploy.sh
+++ b/hack/tests/test_default_deploy.sh
@@ -6,6 +6,7 @@ function tests.setup {
   #initial setup required for all test scenarios
   oc create -f $SOURCE_ROOT/metrics-deployer-setup.yaml &> /dev/null || true
   oadm policy add-role-to-user edit system:serviceaccount:${TEST_PROJECT}:metrics-deployer
+  oadm policy add-role-to-user view system:serviceaccount:${TEST_PROJECT}:hawkular
   oadm policy add-cluster-role-to-user cluster-reader system:serviceaccount:${TEST_PROJECT}:heapster
 }
 
@@ -13,6 +14,7 @@ function tests.teardown {
   oc delete -f $SOURCE_ROOT/metrics-deployer-setup.yaml &> /dev/null || true
   #clean up required after the tests have run.
   oadm policy remove-role-from-user edit system:serviceaccount:${TEST_PROJECT}:metrics-deployer
+  oadm policy remove-role-from-user view system:serviceaccount:${TEST_PROJECT}:hawkular
   oadm policy remove-cluster-role-from-user cluster-reader system:serviceaccount:${TEST_PROJECT}:heapster
 }
 

--- a/hawkular-metrics/hawkular-metrics-wrapper.sh
+++ b/hawkular-metrics/hawkular-metrics-wrapper.sh
@@ -53,6 +53,20 @@ do
   fi
 done
 
+# Check Read Permission
+token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+url="${MASTER_URL}/api/${KUBERNETES_API_VERSION:-v1}/namespaces/${POD_NAMESPACE}/replicationcontrollers/hawkular-metrics"
+cacrt="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+status_code=$(curl --cacert ${cacrt} --max-time 10 --connect-timeout 10 -L -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${token}" $url)
+if [ "$status_code" != 200 ]; then
+  echo "Error: the service account for Hawkular Metrics does not have permission to view resources in this namespace. View permissions are required for Hawkular Metrics to function properly."
+  echo "       usually this can be resolved by running: oc policy add-role-to-user view system:serviceaccount:${POD_NAMESPACE}:hawkular"
+  exit 1
+else
+  echo "The service account has read permissions for its project. Proceeding"
+fi
+
 if [ -n "$KEYSTORE_PASSWORD_FILE" ]; then
    KEYSTORE_PASSWORD=$(cat $KEYSTORE_PASSWORD_FILE)
 fi


### PR DESCRIPTION
Adds docs that the Hawkular service account needs special permissions (required for wildfly/eap jgroups clustering).

Adds check to the Hawkular Metrics image so that it will fail with an error message if the service account does not have the right permissions. This is to help prevent the instances from starting if clustering cannot be enabled.
