### PR TITLE
Added a Makefile with a target to build Docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+# Build the Docker images for Origin Aggregated Logging
+build-images:
+	hack/build-images.sh
+.PHONY: build-images


### PR DESCRIPTION
In order to interface with the origin-ci-tool that will be
replacing the vagrant-openshfit repository, all actions that
a user (or the CI system) will want to do in this repository
should be supported with a `make` target. This decision to
use `make` as the API between users and the repository was
made with the express purpose of reducing the amount of
complexity that any tool would have to contain.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>