### PR TITLE
Set the default Cassandra policy to ignore commit log replay errors

### DIFF
--- a/deployer/templates/hawkular-cassandra-node-dynamic-pv.yaml
+++ b/deployer/templates/hawkular-cassandra-node-dynamic-pv.yaml
@@ -94,6 +94,8 @@ objects:
             value: "${MASTER}"
           - name: CASSANDRA_DATA_VOLUME
             value: "/cassandra_data"
+          - name: JVM_OPTS
+            value: "-Dcassandra.commitlog.ignorereplayerrors=true"
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:

--- a/deployer/templates/hawkular-cassandra-node-emptydir.yaml
+++ b/deployer/templates/hawkular-cassandra-node-emptydir.yaml
@@ -74,6 +74,8 @@ objects:
             value: "${MASTER}"
           - name: CASSANDRA_DATA_VOLUME
             value: "/cassandra_data"
+          - name: JVM_OPTS
+            value: "-Dcassandra.commitlog.ignorereplayerrors=true"
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:

--- a/deployer/templates/hawkular-cassandra-node-pv.yaml
+++ b/deployer/templates/hawkular-cassandra-node-pv.yaml
@@ -92,6 +92,8 @@ objects:
             value: "${MASTER}"
           - name: CASSANDRA_DATA_VOLUME
             value: "/cassandra_data"
+          - name: JVM_OPTS
+            value: "-Dcassandra.commitlog.ignorereplayerrors=true"
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:


### PR DESCRIPTION
If the Cassandra instance is shut down incorrectly, there is a chance that the commit logs could become corrupted and not be usable. This normally forces an admin to go in and manually delete the commit logs before restarting the server will be possible.

This makes a change that will allow Cassandra to continue if a commit log is corrupted and not salvageable. Allowing the server to continue to boot up.