### PR TITLE
chnaged --connect-timeout=2 to --connect-timeout=20

### DIFF
--- a/deployer/scripts/preflight.sh
+++ b/deployer/scripts/preflight.sh
@@ -3,7 +3,7 @@
 # determine whether DNS resolves the master successfully
 function validate_master_accessible() {
   local output
-  if output=$(curl -sSI --stderr - --connect-timeout 2 --cacert "$master_ca" "$master_url"); then
+  if output=$(curl -sSI --stderr - --connect-timeout 20 --cacert "$master_ca" "$master_url"); then
     echo "ok"
     return 0
   fi


### PR DESCRIPTION
In heavy loaded OCP clusters ( busy network / busy master ) PREFLIGHT will fail as it does not reach master url within defined 2 seconds. Increasing this to higher value is helping PREFLIGHT phase to pass. 

Signed-off-by: Elvir Kuric <elvirkuric@gmail.com>