### PR TITLE
added support for heapster to push metrics into additional sinks

### DIFF
--- a/deployer/scripts/heapster.sh
+++ b/deployer/scripts/heapster.sh
@@ -83,7 +83,18 @@ EOF
   if [ -n "${HEAPSTER_STANDALONE:-}" ]; then
     oc create -f templates/heapster-standalone.yaml
   else
-    oc create -f templates/heapster.yaml
+    echo "Processing sinks for Heapster"
+    if [ -n "${ADDITIONAL_HEAPSTER_SINKS:-}"  ]; then
+        cp templates/heapster.yaml /tmp/heapster.yaml
+        for SINK in $(echo -e "$ADDITIONAL_HEAPSTER_SINKS");do
+          sed -i "/--source/a \
+              \ \ \ \ \ \ \ \ \ \ - \"--sink=${SINK}\" /tmp/heapster.yaml"
+        done
+        oc create -f /tmp/heapster.yaml
+        rm -f /tmp/heapster.yaml
+    else
+        oc create -f templates/heapster.yaml
+    fi
   fi
   
   echo "Deploying the Heapster component"

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -88,6 +88,8 @@ objects:
           value: ${METRIC_RESOLUTION}
         - name: STARTUP_TIMEOUT
           value: ${STARTUP_TIMEOUT}
+        - name: ADDITIONAL_HEAPSTER_SINKS
+          value: ${ADDITIONAL_HEAPSTER_SINKS}
     dnsPolicy: ClusterFirst
     restartPolicy: Never
     serviceAccount: metrics-deployer
@@ -166,3 +168,6 @@ parameters:
   description: "How long in seconds we should wait until Hawkular Metrics and Heapster starts up before attempting a restart"
   name: STARTUP_TIMEOUT
   value: "500"
+-
+  description: "A list separated by spaces with the additinal sinks where heapster will push metrics"
+  name: ADDITIONAL_HEAPSTER_SINKS


### PR DESCRIPTION
I have created a POC where Heapster sinks into Hawkular and Kafka at same time. 
This is an excerpt Heapster pod's log.
```
The endpoint check has successfully completed.
Starting Heapster with the following arguments: --source=kubernetes:https://kubernetes.default.svc:443?useServiceAccount=true&kubeletHttps=true&kubeletPort=10250 --sink=kafka:?brokers=10.44.92.124:9092&timeseriestopic=heapster-metrics&eventstopic=heapster-events --sink=hawkular:https://hawkular-metrics:443?tenant=_system&labelToTenant=pod_namespace&labelNodeId=nodename&caCert=/hawkular-cert/hawkular-metrics-ca.certificate&user=hawkular&pass=Z2xLfm_xpktqU9A&filter=label(container_name:^system.slice.*|^user.slice) --tls_cert=/secrets/heapster.cert --tls_key=/secrets/heapster.key --tls_client_ca=/secrets/heapster.client-ca --allowed_users=system:master-proxy
I1117 13:33:31.970560       1 heapster.go:60] heapster --source=kubernetes:https://kubernetes.default.svc:443?useServiceAccount=true&kubeletHttps=true&kubeletPort=10250 --sink=kafka:?brokers=10.44.92.124:9092&timeseriestopic=heapster-metrics&eventstopic=heapster-events --sink=hawkular:https://hawkular-metrics:443?tenant=_system&labelToTenant=pod_namespace&labelNodeId=nodename&caCert=/hawkular-cert/hawkular-metrics-ca.certificate&user=hawkular&pass=Z2xLfm_xpktqU9A&filter=label(container_name:^system.slice.*|^user.slice) --tls_cert=/secrets/heapster.cert --tls_key=/secrets/heapster.key --tls_client_ca=/secrets/heapster.client-ca --allowed_users=system:master-proxy
I1117 13:33:31.970629       1 heapster.go:61] Heapster version 1.1.0-beta1
I1117 13:33:31.970918       1 configs.go:60] Using Kubernetes client with master "https://kubernetes.default.svc:443" and version "v1"
I1117 13:33:31.970936       1 configs.go:61] Using kubelet port 10250
I1117 13:33:32.006047       1 driver.go:322] Initialised Hawkular Sink with parameters {_system https://hawkular-metrics:443?tenant=_system&labelToTenant=pod_namespace&labelNodeId=nodename&caCert=/hawkular-cert/hawkular-metrics-ca.certificate&user=hawkular&pass=Z2xLfm_xpktqU9A&filter=label(container_name:^system.slice.*|^user.slice) 0xc8202a6500  5}
I1117 13:33:32.109396       1 heapster.go:87] Starting with Apache Kafka Sink
I1117 13:33:32.109433       1 heapster.go:87] Starting with Hawkular-Metrics Sink
I1117 13:33:32.109444       1 heapster.go:87] Starting with Metric Sink
I1117 13:33:32.117797       1 heapster.go:166] Starting heapster on port 8082
I1117 13:34:05.000269       1 manager.go:79] Scraping metrics start: 2016-11-17 13:33:30 +0000 UTC, end: 2016-11-17 13:34:00 +0000 UTC
I1117 13:34:05.100668       1 manager.go:152] ScrapeMetrics: time: 100.240369ms size: 190
```
And here an excerpt from kafka 
```
{"MetricsName":"cpu/request","MetricsValue":{"value":0},"MetricsTimestamp":"2016-11-17T13:41:30Z","MetricsTags":{"namespace_id":"3a5b026f-acb0-11e6-b27f-42010a2c5c7b","namespace_name":"default","type":"ns"}}
{"MetricsName":"cpu/limit","MetricsValue":{"value":0},"MetricsTimestamp":"2016-11-17T13:41:30Z","MetricsTags":{"namespace_id":"3a5b026f-acb0-11e6-b27f-42010a2c5c7b","namespace_name":"default","type":"ns"}}
{"MetricsName":"memory/request","MetricsValue":{"value":157286400},"MetricsTimestamp":"2016-11-17T13:41:30Z","MetricsTags":{"namespace_id":"3a5b026f-acb0-11e6-b27f-42010a2c5c7b","namespace_name":"default","type":"ns"}}
{"MetricsName":"memory/limit","MetricsValue":{"value":235929600},"MetricsTimestamp":"2016-11-17T13:41:30Z","MetricsTags":{"namespace_id":"3a5b026f-acb0-11e6-b27f-42010a2c5c7b","namespace_name":"default","type":"ns"}}
{"MetricsName":"cpu/usage_rate","MetricsValue":{"value":3},"MetricsTimestamp":"2016-11-17T13:41:30Z","MetricsTags":{"namespace_id":"3a5b026f-acb0-11e6-b27f-42010a2c5c7b","namespace_name":"default","type":"ns"}}
{"MetricsName":"memory/usage","MetricsValue":{"value":36089856},"MetricsTimestamp":"2016-11-17T13:41:30Z","MetricsTags":{"namespace_id":"3a5b026f-acb0-11e6-b27f-42010a2c5c7b","namespace_name":"default","type":"ns"}}
{"MetricsName":"memory/usage","MetricsValue":{"value":36089856},"MetricsTimestamp":"2016-11-17T13:41:30Z","MetricsTags":{"namespace_id":"3a5b026f-acb0-11e6-b27f-42010a2c5c7b","namespace_name":"default","type":"ns"}}
{"MetricsName":"cpu/request","MetricsValue":{"value":0},"MetricsTimestamp":"2016-11-17T13:41:30Z","MetricsTags":{"namespace_id":"3a5b026f-acb0-11e6-b27f-42010a2c5c7b","namespace_name":"default","type":"ns"}}
{"MetricsName":"cpu/limit","MetricsValue":{"value":0},"MetricsTimestamp":"2016-11-17T13:41:30Z","MetricsTags":{"namespace_id":"3a5b026f-acb0-11e6-b27f-42010a2c5c7b","namespace_name":"default","type":"ns"}}
{"MetricsName":"memory/request","MetricsValue":{"value":157286400},"MetricsTimestamp":"2016-11-17T13:41:30Z","MetricsTags":{"namespace_id":"3a5b026f-acb0-11e6-b27f-42010a2c5c7b","namespace_name":"default","type":"ns"}}
{"MetricsName":"memory/limit","MetricsValue":{"value":235929600},"MetricsTimestamp":"2016-11-17T13:41:30Z","MetricsTags":{"namespace_id":"3a5b026f-acb0-11e6-b27f-42010a2c5c7b","namespace_name":"default","type":"ns"}}
{"MetricsName":"cpu/usage_rate","MetricsValue":{"value":3},"MetricsTimestamp":"2016-11-17T13:41:30Z","MetricsTags":{"namespace_id":"3a5b026f-acb0-11e6-b27f-42010a2c5c7b","namespace_name":"default","type":"ns"}}
```