### PR TITLE
wip keystores/truststores

### DIFF
--- a/hawkular-metrics/hawkular-metrics-wrapper.sh
+++ b/hawkular-metrics/hawkular-metrics-wrapper.sh
@@ -125,8 +125,27 @@ HAWKULAR_METRICS_AUTH_DIR=$HAWKULAR_METRICS_DIRECTORY/auth
 mkdir $HAWKULAR_METRICS_AUTH_DIR
 pushd $HAWKULAR_METRICS_AUTH_DIR
 
-cp $KEYSTORE hawkular-metrics.keystore
-cp $TRUSTSTORE hawkular-metrics.truststore
+if [ "${KEYSTORE##*.}" != pkcs12 ]; then
+  cp $KEYSTORE hawkular-metrics.keystore
+else
+  keytool -v -importkeystore \
+    -srckeystore "$KEYSTORE" \
+    -srcstoretype PKCS12 \
+    -destkeystore "$HAWKULAR_METRICS_AUTH_DIR/hawkular-metrics.keystore" \
+    -deststoretype JKS \
+    -srcstorepass "$KEYSTORE_PASSWORD" \
+    -deststorepass "$KEYSTORE_PASSWORD"
+fi
+if [ "$TRUSTSTORE" ]; then
+  cp $TRUSTSTORE hawkular-metrics.truststore
+else
+  TRUSTSTORE=$HAWKULAR_METRICS_AUTH_DIR/hawkular-metrics.truststore
+  for f in hawkular-cassandra ca; do
+    keytool -noprompt -import -v -trustcacerts \
+      -alias "$f" -file "/secrets/$f.crt" \
+      -keystore "$TRUSTSTORE" -storepass "$TRUSTSTORE_PASSWORD"
+  done
+fi
 
 chmod a+rw hawkular-metrics.*
 


### PR DESCRIPTION
Adding the option to create the key/trust stores in the individual containers.

The only one left is the hawkular-metrics jgroups keystore, but I've hit a
roadblock.  Unlike the others, it is a JCEKS, not a JKS, and [there is no way
to import a secret key to it with keytool][keytool_jceks].  And it has to be
passed in (as opposed to being created inside the container) if there will be
more than one hawkular-metrics instance.

From the [jgroups docs][jgroup_docs], the only way to pass the key for
symmetric encryption is through a keystore.  There is also the option to do
asymmetric encryption, which only requires a shared (plain text) secret.

So the two options I see here are:

- have custom java code on the hawkular-metrics image to create the keystore
- change the encryption method to asymmetric

I'm not a fan of any, but I can't think of any other solution.  Is there
something I'm missing?  Do you have a suggestion?

[keytool_jceks]: http://superuser.com/questions/766504/how-do-i-import-a-raw-aes-key-to-a-jceks-keystore/766589
[jgroup_docs]: http://www.jgroups.org/manual4/index.html#Security