### PR TITLE
Fix typo in cassandra-docker.sh parameter

### DIFF
--- a/cassandra/cassandra-docker.sh
+++ b/cassandra/cassandra-docker.sh
@@ -58,7 +58,7 @@ do
     --truststore_file=*)
       TRUSTSTORE_FILE="${args#*=}"
     ;;
-    --trustsotre_password=*)
+    --truststore_password=* | --trustsotre_password=*)
       TRUSTSTORE_PASSWORD="${args#*=}"
     ;;
     --truststore_password_file=*)


### PR DESCRIPTION
The "--truststore_password" parameter had a typo. The old version,
"--trustsotre_password", is still accepted in case it's used somewhere.