### PR TITLE
Deprecate the old deployer way of installing metrics.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,321 +1,86 @@
+[NOTE]
+====
+How metrics is installed has changed from using the deployer pod to using ansible.
+
+Please see the link:https://docs.openshift.org/latest/install_config/cluster_metrics.html[OpenShift Metrics installation instructions] for more information.
+====
+
 = origin-metrics
+
+== About
+
+Origin Metrics is designed to gather container, pod and node metrics from across an entire OpenShift cluster. These metrics can then be viewed in the OpenShift Console or exported to another system.
+
+It achieves this goals via these main components:
+
+==== Heapster
+link:https://github.com/kubernetes/heapster[Heapster] gathers the metrics from across the OpenShift cluster. It retrieves metadata associated with the cluster from the master API and retrieves individual metrics from the `/stats` endpoint which is exposed on each individual OpenShift node.
+
+It gathers system level metrics such as CPU, Memory, Network, etc
+
+Heapster will then send these metrics to Hawkular Metrics and expose a REST endpoint that the horizontal pod autoscaler (HPA) uses.
+
+==== Hawkular Metrics
+link:https://github.com/hawkular/hawkular-metrics/[Hawkular Metrics] is the metric storage engine from the link:http://www.hawkular.org/[Hawkular] project. It provides means of creating, accessing and managing historically stored metrics via an easy to use json based REST interface.
+
+Hawkular Metrics uses Cassandra as its metric datastore.
+
+It receives metrics from the Heapster component and is also used to expose metrics to the console and other third party systems.
+
+==== Cassandra
+link:http://cassandra.apache.org/[Cassandra] is the data store for Hawkular Metrics. It stores and persists all the metrics coming in from Hawkular Metrics.
+
+==== Hawkular OpenShift Agent
+The link:https://github.com/hawkular/hawkular-openshift-agent[Hawkular OpenShift Agent] is a component which can be used to gather application level metrics coming from pods. This allows pods themselves to expose metrics that they wish to be collected.
+
+This component runs as a deamon set across the OpenShift cluster and is responsible for gathering application level metrics from each pod running on that node.
 
 [NOTE]
 ====
-This document and its corresponding containers are meant to run on version v1.0.8 or later of link:https://github.com/openshift/origin[OpenShift Origin]
+The Hawkular OpenShift Agent is currently in Tech Preview.
 ====
-
-The following document will describe how to build, configure and install the metric components for OpenShift.
-
-The metric components will gather metrics for all containers and nodes across an entire OpenShift cluster. As such it needs to be performed by a cluster administrator.
-
-== Overview
-
-There are three main components to the metrics gathering:
-
-=== Heapster
-
-link:https://github.com/kubernetes/heapster[Heapster] is the component which gathers the various metrics from the OpenShift cluster. It connects to each node in an OpenShift cluster and reads the kubelet's `/stats` endpoint to retrieve metrics.
-
-```
- +----------+
- | Heapster |
- +-----+----+
- |     |   read /stats
- |     +---------------------> kubelet1
- |     |
- |     |   read /stats
- |     +---------------------> kubelet2
- |
- |              ...
- |
- |
- |
- |       write /hawkular/metrics/
- +------------------------------>  Hawkular
-                                    ^    +
-                                    |    |
- 	Hawkular Console +----------|    |
-                                         |
-                                         v
-
-                                       cassandra
-```
-
-Heapster retrieves metrics (i.e. cpu, memory, ...) for every container running in the cluster, across all namespaces.
-
-It also retrieves metrics for the node itself, the kubelet, and the docker daemon.
-
-Heapster does not store metrics itself.
-
-==== Hawkular Metrics
-
-link:https://github.com/hawkular/hawkular-metrics/[Hawkular Metrics] is the metric storage engine from the link:http://www.hawkular.org/[Hawkular] project. It provides means of creating, accessing and managing historically stored metrics via an easy to use json based REST interface.
-
-Heapster sends the metrics it receives to Hawkular Metrics over the Hawkular Metric REST interface.
-
-Hawkular Metrics then stores the metrics into a link:http://cassandra.apache.org/[Cassandra] database.
-
-== Building the Docker Containers
-
-All the docker images for Origin Metric components are available at link:https://hub.docker.com/search/?q=openshift%2Forigin-metrics&page=1&isAutomated=0&isOfficial=0&starCount=0&pullCount=0[docker hub] and there should not be a need to build these directly.
-
-If you wish to build your own images or hack on the project. Please see the link:docs/build.adoc[build instructions].
 
 == Before You Begin
 
 The Metrics components requires that OpenShift is properly installed and configured. How to properly install and configure OpenShift is beyond the scope of this document. Please see the link:https://docs.openshift.org/latest/welcome/index.html[OpenShift documentation] on how to properly install and setup your system.
 
-There are a few things which you will specifically need to make sure are properly configured with your OpenShift instance:
-
-. The link:docs/troubleshooting.adoc#checking-if-the-dns-service-is-running-or-not[OpenShift DNS server] needs to be properly running on your system.
-
-. link:docs/troubleshooting.adoc#empty-charts[Node certificate problems] if your OpenShift installation was originally installed on an older version.
-
-. SELinux and firewall configurations may cause problems if not properly configured.
+The metrics install requires integation with the OpenShift cluster and if there are installation or configuration problems with your OpenShift cluster you may encounter them when tyring to running metrics. Some of the more common issues are checked in the deployer pod and will give you an error message about your installation.
 
 Please see the link:docs/troubleshooting.adoc[troubleshooting guide] for a complete list of things to watch out for.
 
-== Deploying the Origin Metrics Components
+== Installing
+
+The link:https://docs.openshift.org/latest/install_config/cluster_metrics.html[OpenShift documentation] describes how to install metrics.
 
 [NOTE]
 ====
-In order to use the horizontal pod autoscaler (HPA), all of the metric components will need to be deployed to the `openshift-infra` project.
+The old way of deploying metrics which rely on using the deployer pod is now deprecated. For the old instructions please see the link:docs/deployer_installation.adoc[deployer installation page].
 ====
 
-=== Create the Deployer Service Account
+== Deploying the Hawkular OpenShift Agent
 
-A pod is used to setup, configure and deploy all the various metric components. This deployer pod is run under the `metrics-deployer` service account.
+A few steps are required to deploy the link:https://github.com/hawkular/hawkular-openshift-agent[Hawkular OpenShift Agent] into OpenShift.
 
-The `metrics-deployer` can be created from the link:metrics-deployer-setup.yaml[*_metrics-deployer-setup.yaml_*] configuration file. The following command will create the service account for you:
-
+You will first need to create the ConfigMap that the Agent uses to configure itself:
 ----
-$ oc create -f metrics-deployer-setup.yaml -n openshift-infra
-----
-
-=== Metrics Deployer Service Account
-
-In order to deploy components within the project, the `metrics-deployer` service account needs to be granted the 'edit' permission.
-
-This can be accomplished by running the following command:
-
-----
-$ oadm policy add-role-to-user edit \
-        system:serviceaccount:openshift-infra:metrics-deployer \
-        -n openshift-infra
+$oc create -f deploy/openshift/hawkular-openshift-agent-configmap.yaml -n openshift-infra
 ----
 
-=== Hawkular Service Account
-
-The hawkular service account requires `view` permissions in order to gather information about pods that will make up a Hawkular Metrics cluster.
-
-Run the following command to add the `view` permission to the `hawkular` service account:
-
+You will then need to process the Agent's template and deploy its components:
 ----
-$ oadm policy add-role-to-user view \
-        system:serviceaccount:openshift-infra:hawkular \
-        -n openshift-infra
+$oc process -f deploy/openshift/hawkular-openshift-agent.yaml | oc create -n openshift-infra -f -
 ----
 
-
-=== Heapster Service Account
-
-The heapster component requires accessing the kubernetes node to find all the available nodes as well as accessing the `/stats` endpoint on each of those nodes. This means that the `heapster` service account which requires having the `cluster-reader` permission.
-
-The following command will give the `heapster` service account the required permission:
-
+Finally you will need to grant the `hawkular-openshift-agent`'s service acount the proper permissions:
 ----
-$ oadm policy add-cluster-role-to-user cluster-reader \
-        system:serviceaccount:openshift-infra:heapster \
-        -n openshift-infra
+$oc adm policy add-cluster-role-to-user hawkular-openshift-agent system:serviceaccount:openshift-infra:hawkular-openshift-agent
 ----
 
-=== Create the Metrics Deployer Secret
+Once this is completed, the `Hawkular OpenShift Agent` should be deployed into the `openshift-infra` project.
 
-The *metrics deployer* auto-generates self-signed certificates for
-use internally between components.
+If you are running the latest OpenShift, you should be able to verify that the agent is functioning by seeing extra metrics showing up under the agent's pod metric page.
 
-Since *Hawkular Metrics* needs to be accessed outside of the internal network in the OpenShift Console, it will create
-a re-encrypting route for this purpose. By default this will use the router's certificate for the SSL connections, but you can provide your
-own certificate as a secret for the deployer which will allow you to use your own certificates in this re-encrypting route.
-
-To provide your own certificates, you can pass these
-values as secrets to the *metrics deployer*.
-
-For instance, to optionally provide your own certificates for Hawkular Metrics, you can point your secret to the certificate's *_.pem_* (which has to include the private key) and certificate authority file:
-
-----
-$ oc secrets new metrics-deployer hawkular-metrics.pem=/home/openshift/metrics/hm.pem \
-hawkular-metrics-ca.cert=/home/openshift/metrics/hm-ca.cert -n openshift-infra
-----
-
-If you do not wish to provie your own certificates and use the router's certificates instead, you will just need to generate an empty secret:
-
-----
-$ oc secrets new metrics-deployer nothing=/dev/null -n openshift-infra
-----
-
-For a full listing of all the available secrets for the Origin Metrics deployer, please see the link:docs/deployer_configuration.adoc#deployer-secrets[deployer configuration] page.
-
-=== Deploying Only Heapster
-
-If you do not wish to deploy the Hawkular Metrics and Cassandra containers, it is possible to just deploy the Heapster components in a stand alone manner.
-
-If you do wish to deploy all the metrics components and have access to metric graphs in the OpenShift console, please continue to the link:#deploying-all-of-the-metrics-components[Deploying all of the Metrics Components] section.
-
-[WARNING]
-====
-The OpenShift console uses Hawkular Metrics for its graphing capabilities. If you only deploy Heapster you will not be able to view any metrics in the console.
-====
-
-The Heapster deployer template does not have an required parameters and will fallback to defaults. For a full list of parameters options please see the link:docs/deployer_configuration.adoc#deployer-template-parameters[deployer configuration] page.
-
-You should only run the following command if you are sure that you only want the Heapster component to be deployed:
-
-----
-$ oc process -f metrics-heapster.yaml | oc create -n openshift-infra -f -
-----
-
-=== Deploying all of the Metrics Components
-
-==== Persistent Storage
-
-You can deploy the metrics components with or without persistent storage.
-
-Running with persistent storage means that your metrics will be stored to a link:https://docs.openshift.org/latest/architecture/additional_concepts/storage.html[persistent volume] and be able to survive a pod being restarted or recreated. This requires an admin to have setup and made available a persistent volume of sufficient size. Running with persistent storage is highly recommended if you require metric data to be guarded against data loss. Please see the link:docs/persistent_storage.adoc[persistent storage] page for more information.
-
-Running with non-persistent storage means that any stored metrics will be deleted when the pod is deleted or restarted. Metrics will still survive a container being restarted. It is much easier to run with non-persistent data, but with the tradeoff of potentially losing this metric data. Running with non-persistent data should only be done when data loss under certain situations is acceptable.
-
-
-[IMPORTANT]
-====
-When using persistent storage you will need to make sure that your storage size is appropriate for your needs. The Cassandra database can and will use up all the available space allocated to the Persistent Volume which will cause serious errors.
-
-Metric data expires based on the *METRIC_DURATION* template parameter. Normally this means that older data is being removed at about the same pace as newer data arrives. You will still need to monitor your data usage to make sure that changes to your cluster have not caused your usage to increase beyond what your persistent volume will be able to handle.
-====
-
-
-==== Deployer Template
-
-To deploy the metric components, you will need to deploy the 'metrics' template.
-
-The only required template parameter is `HAWKULAR_METRICS_HOSTNAME`. This parameter specifies the hostname that hawkular metrics is going to be hosted under. This is used to generate the Hawkular Metrics certificate and is used for the host in the route configuration.
-
-For the full list of deployer template options, please see the link:docs/deployer_configuration.adoc#deployer-template-parameters[deployer configuration] page.
-
-[NOTE]
-====
-The following options assume that the kubernetes master will be available under `https://kubernetes.default.svc:443` if this is not the case please set the link:docs/deployer_configuration.adoc#deployer-template-parameters[MASTER_URL]. Failure to properly set this may result in strange i/o timeout errors in the deployer logs.
-====
-
-If you are using non-persistent data, the following command will deploy the metric components without requiring a persistent volume to be created before hand:
-
-----
-$ oc process -f metrics.yaml \
-       -v HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
-       -v USE_PERSISTENT_STORAGE=false \
-     | oc create -n openshift-infra -f -
-----
-
-If you are using persistent data, the following command will deploy the metric components but requires a storage volume of sufficient size to be available:
-
-----
-$ oc process -f metrics.yaml \
-     -v HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
-     -v USE_PERSISTENT_STORAGE=true \
-     | oc create -n openshift-infra -f -
-----
-
-[NOTE]
-====
-If you ever wish to undeploy and then redeploy all the metric components, you can do so by setting the `MODE` template parameter to 'redeploy'. Note that this will also remove any persistent volume claims and any persisted data will be lost.
-Any non persisted data will be lost as well. This is equivalent to deleting all the components and then restarting everything overagain.
-
-For example:
-----
-$ oc process -f metrics.yaml \
-     -v HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
-     -v USE_PERSISTENT_STORAGE=false \
-     -v MODE=redeploy \
-     | oc create -n openshift-infra -f -
-----
-
-The `refresh` value for `MODE` performs the same steps as 'redeploy' but the persistent volume claims and route will not be deleted. Any non-persisted data will be lost with this operation. This option is useful if you wish
-to redeploy your components with updated deployer secrets or if you wish to deploy another newer version.
-
-For example:
-----
-$ oc process -f metrics.yaml \
-     -v HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
-     -v USE_PERSISTENT_STORAGE=false \
-     -v MODE=refresh \
-     | oc create -n openshift-infra -f -
-----
-
-To manually delete the pvc and route, you can run the following command:
-
-----
-$ oc delete pvc --selector="metrics-infra"
-$ oc delete route --selector="metrics-infra"
-----
-====
-
-== Verifying the Components after Installation
-
-The first check should always be to see that the Hawkular Metrics, Cassandra, and Heapster pods are in the running state.
-
-----
-$ oc get pods -n openshift-infra
-----
-
-If all pods are in the running state, then you will want to check the Hawkular-Metrics status page:
-
-----
-$ curl -X GET https://${HAWKULAR_METRICS_HOSTNAME}/hawkular/metrics/status
-----
-
-This will return a short json document. The important thing to look at here is the `MetricsService` value, if this is `STARTED` then it means that Hawkular Metrics has fully started and was able to successfully connect to Cassandra.
-
-The next step will be to check the Heapster validate page. The link:#accessing-heapster-directly[Accessing Heapster Directly] section fully describes how to connect to this page. This page will show you some information about the current Heapster setup as well as how many metrics it knows about and has written into Hawkular Metrics.
-
-Please see the link:docs/troubleshooting.adoc[troubleshooting guide] if you are running into any issues.
-
-
-== Configurations for the OpenShift Console
-
-The OpenShift web console uses the data coming from the Hawkular Metrics service
-to display its graphs. The URL for accessing the Hawkular Metrics service
-must be configured via the `*metricsPublicURL*` option in the *_master-config.yaml_*
-file. This URL corresponds to the route created with the
-`*HAWKULAR_METRICS_HOSTNAME*` template parameter during the
-link:#deploying-the-metrics-components[deployment]
-of the metrics components.
-
-[NOTE]
-====
-You must be able to resolve the `*HAWKULAR_METRICS_HOSTNAME*` from the browser
-accessing the console.
-====
-
-For example, if your `*HAWKULAR_METRICS_HOSTNAME*` corresponds to `hawkular-metrics.example.com`, then you must make the following change in the *_master-config.yaml_* file:
-
-====
-[source,yaml,]
-.master-config.yaml
-----
-  assetConfig:
-    ...
-    metricsPublicURL: "https://hawkular-metrics.example.com/hawkular/metrics"
-----
-====
-
-Once you have updated and saved the *_master-config.yaml_* file, you must
-restart your OpenShift instance.
-
-When your OpenShift server is back up and running, metrics will be displayed on
-the pod overview pages.
-
-image::docs/images/openshift_console_graphs.png["OpenShift Console Charts"]
+For instructions on how to expose custom metrics on your own pod and for more information about the agent itself, please the the link:https://github.com/hawkular/hawkular-openshift-agent[Hawkular OpenShift Agent] project.
 
 == Accessing Metrics Directly
 
@@ -362,6 +127,13 @@ If you wish to remove the deployer's components themselves
 ----
 $ oc delete sa,secret metrics-deployer -n openshift-infra
 ----
+
+
+== Docker Containers
+
+All the docker images for Origin Metric components are available at link:https://hub.docker.com/search/?q=openshift%2Forigin-metrics&page=1&isAutomated=0&isOfficial=0&starCount=0&pullCount=0[docker hub] and there should not be a need to build these directly.
+
+If you wish to build your own images or hack on the project. Please see the link:docs/build.adoc[build instructions].
 
 == Known Issues
 

--- a/docs/deployer_installation.adoc
+++ b/docs/deployer_installation.adoc
@@ -1,0 +1,247 @@
+= DEPRECATED =
+
+[WARNING]
+====
+The deployer is being deprecated and the new recommended approach is to use Ansible for the metrics installation.
+
+Please see the link:https://docs.openshift.org/latest/install_config/cluster_metrics.html[OpenShift Metrics installation instructions]
+====
+
+= Installing Origin Metrics using the Deployer Pod
+
+[NOTE]
+====
+In order to support the horizontal pod autoscaler (HPA), all of the metric components will need to be deployed to the `openshift-infra` project.
+====
+
+=== Deployer Service Account
+
+A pod is used to setup, configure and deploy all the various metric components. This deployer pod is run under the `metrics-deployer` service account.
+
+The `metrics-deployer` service account can be created from the link:metrics-deployer-setup.yaml[*_metrics-deployer-setup.yaml_*] configuration file. The following command will create the service account for you:
+
+----
+$ oc create -f metrics-deployer-setup.yaml -n openshift-infra
+----
+
+In order to deploy components within the project, the `metrics-deployer` service account needs to be granted the 'edit' permission.
+
+This can be accomplished by running the following command:
+
+----
+$ oadm policy add-role-to-user edit \
+        system:serviceaccount:openshift-infra:metrics-deployer \
+        -n openshift-infra
+----
+
+=== Hawkular Service Account
+
+The hawkular service account requires `view` permissions in order to gather information about the pods that will make up a Hawkular Metrics cluster.
+
+Run the following command to add the `view` permission to the `hawkular` service account:
+
+----
+$ oadm policy add-role-to-user view \
+        system:serviceaccount:openshift-infra:hawkular \
+        -n openshift-infra
+----
+
+
+=== Heapster Service Account
+
+The heapster component requires accessing the kubernetes node to find all the available nodes as well as accessing the `/stats` endpoint on each of those nodes. This means that the `heapster` service account which requires having the `cluster-reader` permission.
+
+The following command will give the `heapster` service account the required permission:
+
+----
+$ oadm policy add-cluster-role-to-user cluster-reader \
+        system:serviceaccount:openshift-infra:heapster \
+        -n openshift-infra
+----
+
+=== Create the Metrics Deployer Secret
+
+The *metrics deployer* auto-generates self-signed certificates for
+use internally between components.
+
+Since *Hawkular Metrics* needs to be accessed outside of the internal network in the OpenShift Console, it will create
+a re-encrypting route for this purpose. By default this will use the router's certificate for the SSL connections, but you can provide your
+own certificate as a secret for the deployer which will allow you to use your own certificates in this re-encrypting route.
+
+To provide your own certificates, you can pass these
+values as secrets to the *metrics deployer*.
+
+For instance, to optionally provide your own certificates for Hawkular Metrics, you can point your secret to the certificate's *_.pem_* (which has to include the private key) and certificate authority file:
+
+----
+$ oc secrets new metrics-deployer hawkular-metrics.pem=/home/openshift/metrics/hm.pem \
+hawkular-metrics-ca.cert=/home/openshift/metrics/hm-ca.cert -n openshift-infra
+----
+
+If you do not wish to provie your own certificates and use the router's certificates instead, you will just need to generate an empty secret:
+
+----
+$ oc secrets new metrics-deployer nothing=/dev/null -n openshift-infra
+----
+
+For a full listing of all the available secrets for the Origin Metrics deployer, please see the link:docs/deployer_configuration.adoc#deployer-secrets[deployer configuration] page.
+
+=== Deploying Only Heapster
+
+If you do not wish to deploy the Hawkular Metrics and Cassandra containers, it is possible to just deploy the Heapster components in a stand alone manner.
+
+If you do wish to deploy all the metrics components and have access to metric graphs in the OpenShift console, please continue to the link:#deploying-all-of-the-metrics-components[Deploying all of the Metrics Components] section.
+
+[WARNING]
+====
+The OpenShift console uses Hawkular Metrics for its graphing capabilities. If you only deploy Heapster you will not be able to view any metrics in the console.
+====
+
+The Heapster deployer template does not have an required parameters and will fallback to defaults. For a full list of parameters options please see the link:docs/deployer_configuration.adoc#deployer-template-parameters[deployer configuration] page.
+
+You should only run the following command if you are sure that you only want the Heapster component to be deployed:
+
+----
+$ oc process -f metrics-heapster.yaml | oc create -n openshift-infra -f -
+----
+
+=== Deploying all of the Metrics Components
+
+==== Persistent Storage
+
+You can deploy the metrics components with or without persistent storage.
+
+Running with persistent storage means that your metrics will be stored to a link:https://docs.openshift.org/latest/architecture/additional_concepts/storage.html[persistent volume] and be able to survive a pod being restarted or recreated. This requires an admin to have setup and made available a persistent volume of sufficient size. Running with persistent storage is highly recommended if you require metric data to be guarded against data loss. Please see the link:docs/persistent_storage.adoc[persistent storage] page for more information.
+
+Running with non-persistent storage means that any stored metrics will be deleted when the pod is deleted or restarted. Metrics will still survive a container being restarted. It is much easier to run with non-persistent data, but with the tradeoff of potentially losing this metric data. Running with non-persistent data should only be done when data loss under certain situations is acceptable.
+
+
+[IMPORTANT]
+====
+When using persistent storage you will need to make sure that your storage size is appropriate for your needs. The Cassandra database can and will use up all the available space allocated to the Persistent Volume which will cause serious errors.
+
+Metric data expires based on the *METRIC_DURATION* template parameter. Normally this means that older data is being removed at about the same pace as newer data arrives. You will still need to monitor your data usage to make sure that changes to your cluster have not caused your usage to increase beyond what your persistent volume will be able to handle.
+====
+
+
+==== Deployer Template
+
+To deploy the metric components, you will need to deploy the 'metrics' template.
+
+The only required template parameter is `HAWKULAR_METRICS_HOSTNAME`. This parameter specifies the hostname that hawkular metrics is going to be hosted under. This is used to generate the Hawkular Metrics certificate and is used for the host in the route configuration.
+
+For the full list of deployer template options, please see the link:docs/deployer_configuration.adoc#deployer-template-parameters[deployer configuration] page.
+
+[NOTE]
+====
+The following options assume that the kubernetes master will be available under `https://kubernetes.default.svc:443` if this is not the case please set the link:docs/deployer_configuration.adoc#deployer-template-parameters[MASTER_URL]. Failure to properly set this may result in strange i/o timeout errors in the deployer logs.
+====
+
+If you are using non-persistent data, the following command will deploy the metric components without requiring a persistent volume to be created before hand:
+
+----
+$ oc process -f metrics.yaml \
+       -v HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
+       -v USE_PERSISTENT_STORAGE=false \
+     | oc create -n openshift-infra -f -
+----
+
+If you are using persistent data, the following command will deploy the metric components but requires a storage volume of sufficient size to be available:
+
+----
+$ oc process -f metrics.yaml \
+     -v HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
+     -v USE_PERSISTENT_STORAGE=true \
+     | oc create -n openshift-infra -f -
+----
+
+[NOTE]
+====
+If you ever wish to undeploy and then redeploy all the metric components, you can do so by setting the `MODE` template parameter to 'redeploy'. Note that this will also remove any persistent volume claims and any persisted data will be lost.
+Any non persisted data will be lost as well. This is equivalent to deleting all the components and then restarting everything overagain.
+
+For example:
+----
+$ oc process -f metrics.yaml \
+     -v HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
+     -v USE_PERSISTENT_STORAGE=false \
+     -v MODE=redeploy \
+     | oc create -n openshift-infra -f -
+----
+
+The `refresh` value for `MODE` performs the same steps as 'redeploy' but the persistent volume claims and route will not be deleted. Any non-persisted data will be lost with this operation. This option is useful if you wish
+to redeploy your components with updated deployer secrets or if you wish to deploy another newer version.
+
+For example:
+----
+$ oc process -f metrics.yaml \
+     -v HAWKULAR_METRICS_HOSTNAME=hawkular-metrics.example.com \
+     -v USE_PERSISTENT_STORAGE=false \
+     -v MODE=refresh \
+     | oc create -n openshift-infra -f -
+----
+
+To manually delete the pvc and route, you can run the following command:
+
+----
+$ oc delete pvc --selector="metrics-infra"
+$ oc delete route --selector="metrics-infra"
+----
+====
+
+== Verifying the Components after Installation
+
+The first check should always be to see that the Hawkular Metrics, Cassandra, and Heapster pods are in the running state.
+
+----
+$ oc get pods -n openshift-infra
+----
+
+If all pods are in the running state, then you will want to check the Hawkular-Metrics status page:
+
+----
+$ curl -X GET https://${HAWKULAR_METRICS_HOSTNAME}/hawkular/metrics/status
+----
+
+This will return a short json document. The important thing to look at here is the `MetricsService` value, if this is `STARTED` then it means that Hawkular Metrics has fully started and was able to successfully connect to Cassandra.
+
+The next step will be to check the Heapster validate page. The link:#accessing-heapster-directly[Accessing Heapster Directly] section fully describes how to connect to this page. This page will show you some information about the current Heapster setup as well as how many metrics it knows about and has written into Hawkular Metrics.
+
+Please see the link:docs/troubleshooting.adoc[troubleshooting guide] if you are running into any issues.
+
+== Configurations for the OpenShift Console
+
+The OpenShift web console uses the data coming from the Hawkular Metrics service
+to display its graphs. The URL for accessing the Hawkular Metrics service
+must be configured via the `*metricsPublicURL*` option in the *_master-config.yaml_*
+file. This URL corresponds to the route created with the
+`*HAWKULAR_METRICS_HOSTNAME*` template parameter during the
+link:#deploying-the-metrics-components[deployment]
+of the metrics components.
+
+[NOTE]
+====
+You must be able to resolve the `*HAWKULAR_METRICS_HOSTNAME*` from the browser
+accessing the console.
+====
+
+For example, if your `*HAWKULAR_METRICS_HOSTNAME*` corresponds to `hawkular-metrics.example.com`, then you must make the following change in the *_master-config.yaml_* file:
+
+====
+[source,yaml,]
+.master-config.yaml
+----
+  assetConfig:
+    ...
+    metricsPublicURL: "https://hawkular-metrics.example.com/hawkular/metrics"
+----
+====
+
+Once you have updated and saved the *_master-config.yaml_* file, you must
+restart your OpenShift instance.
+
+When your OpenShift server is back up and running, metrics will be displayed on
+the pod overview pages.
+
+image::images/openshift_console_graphs.png["OpenShift Console Charts"]
+ 

--- a/hawkular-agent/hawkular-openshift-agent-configmap.yaml
+++ b/hawkular-agent/hawkular-openshift-agent-configmap.yaml
@@ -1,0 +1,63 @@
+id: hawkular-openshift-agent
+kind: ConfigMap
+apiVersion: v1
+name: Hawkular OpenShift Agent Configuration
+metadata:
+  name: hawkular-openshift-agent-configuration
+  labels:
+    metrics-infra: agent
+data:
+  config.yaml: |
+    kubernetes:
+      tenant: ${POD:namespace_name}
+    collector:
+      minimum_collection_interval: 10s
+      default_collection_interval: 30s
+      metric_id_prefix: pod/${POD:uid}/custom/
+      tags:
+        metric_name: ${METRIC:name}
+        description: ${METRIC:description}
+        units: ${METRIC:units}
+        namespace_id: ${POD:namespace_uid}
+        namespace_name: ${POD:namespace_name}
+        node_name: ${POD:node_name}
+        pod_id: ${POD:uid}
+        pod_ip: ${POD:ip}
+        pod_name: ${POD:name}
+        pod_namespace: ${POD:namespace_name}
+        hostname: ${POD:hostname}
+        host_ip: ${POD:host_ip}
+        labels: ${POD:labels}
+        type: pod
+        collector: hawkular_openshift_agent
+        custom_metric: true
+  hawkular-openshift-agent: |
+    endpoints:
+    - type: prometheus
+      protocol: "http"
+      port: 8080
+      path: /metrics
+      collection_interval: 30s
+      metrics:
+      - name: hawkular_openshift_agent_metric_data_points_collected_total
+      - name: process_cpu_seconds_total
+      - name: go_goroutines
+      - name: go_memstats_alloc_bytes
+      - name: go_memstats_gc_sys_bytes
+      - name: go_memstats_heap_alloc_bytes
+      - name: go_memstats_heap_idle_bytes
+      - name: go_memstats_heap_inuse_bytes
+      - name: go_memstats_heap_objects
+      - name: go_memstats_heap_released_bytes
+      - name: go_memstats_heap_sys_bytes
+      - name: go_memstats_last_gc_time_seconds
+      - name: go_memstats_next_gc_bytes
+      - name: go_memstats_other_sys_bytes
+      - name: go_memstats_stack_inuse_bytes
+      - name: go_memstats_stack_sys_bytes
+      - name: go_memstats_sys_bytes
+      - name: process_max_fds
+      - name: process_open_fds
+      - name: process_resident_memory_bytes
+      - name: process_start_time_seconds
+      - name: process_virtual_memory_bytes

--- a/hawkular-agent/hawkular-openshift-agent.yaml
+++ b/hawkular-agent/hawkular-openshift-agent.yaml
@@ -1,0 +1,115 @@
+id: hawkular-openshift-agent
+kind: Template
+apiVersion: v1
+name: Hawkular OpenShift Agent Template
+metadata:
+  name: hawkular-openshift-agent
+  metrics-infra: agent
+parameters:
+- description: The version of the image to use
+  name: IMAGE_VERSION
+  value: 1.0.0.Final
+objects:
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    name: hawkular-openshift-agent
+    labels:
+      metrics-infra: agent
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - namespaces
+    - nodes
+    - pods
+    - projects
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - get
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: hawkular-openshift-agent
+    labels:
+      metrics-infra: agent
+- apiVersion: extensions/v1beta1
+  kind: DaemonSet
+  metadata:
+    name: hawkular-openshift-agent
+    labels:
+      name: hawkular-openshift-agent
+      metrics-infra: agent
+  spec:
+    selector:
+      matchLabels:
+        name: hawkular-openshift-agent
+    template:
+      metadata:
+        labels:
+          name: hawkular-openshift-agent
+          metrics-infra: agent
+      spec:
+        serviceAccount: hawkular-openshift-agent
+        containers:
+        - image: hawkular/hawkular-openshift-agent:${IMAGE_VERSION}
+          name: hawkular-openshift-agent
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          command:
+            - "/opt/hawkular/hawkular-openshift-agent"
+            - "-config"
+            - "/hawkular-openshift-agent-configuration/config.yaml"
+            - "-v"
+            - "4"
+          env:
+          - name: K8S_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: HAWKULAR_SERVER_URL
+            value: https://hawkular-metrics
+          - name: HAWKULAR_SERVER_CA_CERT_FILE
+            value: "/hawkular-metrics-certificate/hawkular-metrics-ca.certificate"
+          - name: HAWKULAR_SERVER_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: hawkular-metrics-account 
+                key: hawkular-metrics.username
+          - name: HAWKULAR_SERVER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: hawkular-metrics-account
+                key: hawkular-metrics.password
+          volumeMounts:
+          - name: hawkular-metrics-certificate
+            mountPath: "/hawkular-metrics-certificate"
+          - name: hawkular-openshift-agent-configuration
+            mountPath: "/hawkular-openshift-agent-configuration"
+        volumes:
+        - name: hawkular-metrics-certificate
+          secret:
+            secretName: hawkular-metrics-certificate
+        - name: hawkular-openshift-agent-configuration
+          configMap:
+            name: hawkular-openshift-agent-configuration
+        - name: hawkular-openshift-agent
+          configMap:
+            name: hawkular-openshift-agent-configuration


### PR DESCRIPTION
Add in instructions on how to deploy the Hawkular OpenShift Agent.