### PR TITLE
Adds the ability to provide extra parameters to the cassandra.yaml configuration file

### DIFF
--- a/cassandra/cassandra-docker.sh
+++ b/cassandra/cassandra-docker.sh
@@ -67,6 +67,9 @@ do
     --cassandra_pem_file=*)
       CASSANDRA_PEM_FILE="${args#*=}"
     ;;
+    --extra_cassandra_yaml_parameters=*)
+      EXTRA_CASSANDRA_YAML_PARAMETERS="${args#*=}"
+    ;;
     --help)
       HELP=true
     ;;
@@ -129,6 +132,9 @@ if [ -n "$HELP" ]; then
   echo
   echo "  --truststore_password_file=TRUSTSTORE_PASSWORD"
   echo "        a file containing only the truststore password"
+  echo
+  echo " --extra_cassandra_yaml_parameters=EXTRA_CASSANDRA_YAML_PARAMETERS"
+  echo "        any extra parameters to be set in the cassandra.yaml file"
   echo
   exit 0
 fi
@@ -269,6 +275,10 @@ if [ -n "$TRUSTSTORE_PASSWORD_FILE" ]; then
 fi
 if [ -n "$TRUSTSTORE_PASSWORD" ]; then
    sed -i 's#${TRUSTSTORE_PASSWORD}#'$TRUSTSTORE_PASSWORD'#g' /opt/apache-cassandra/conf/cassandra.yaml
+fi
+
+if [ -n "$EXTRA_CASSANDRA_YAML_PARAMETERS" ]; then
+   echo -e "$EXTRA_CASSANDRA_YAML_PARAMETERS" >> /opt/apache-cassandra/conf/cassandra.yaml
 fi
 
 # create the cqlshrc file so that cqlsh can be used much more easily from the system


### PR DESCRIPTION
The following option will allow  a user to append additional parameters to the cassandra.yaml file. 

This should allow us to provide an escape hatch for certain rare situations, such as https://bugzilla.redhat.com/show_bug.cgi?id=1418748

I have not exposed this as an option in the deployer/ansible. I don't know if we really want to since this shouldn't be used in most situations.

Another options could be that we add the cassandra.yaml.template file as a configmap, which may also make sense, but leaves it more open to users modifying it and potentially running into more problems because of that.

@jsanda @jcantrill any thoughts?
