### PR TITLE
BZ1421060: deploy the agent to the 'default' project

### DIFF
--- a/hawkular-openshift-agent/hawkular-openshift-agent-configmap.yaml
+++ b/hawkular-openshift-agent/hawkular-openshift-agent-configmap.yaml
@@ -10,6 +10,12 @@ data:
   config.yaml: |
     kubernetes:
       tenant: ${POD:namespace_name}
+    hawkular_server:
+      url: https://hawkular-metrics.openshift-infra.svc.cluster.local       
+      credentials:
+        username: secret:openshift-infra/hawkular-metrics-account/hawkular-metrics.username
+        password: secret:openshift-infra/hawkular-metrics-account/hawkular-metrics.password
+      ca_cert_file: secret:openshift-infra/hawkular-metrics-certificate/hawkular-metrics-ca.certificate
     emitter:
       status_enabled: false
     collector:
@@ -42,3 +48,6 @@ data:
       collection_interval: 30s
       metrics:
       - name: hawkular_openshift_agent_metric_data_points_collected_total
+      - name: hawkular_openshift_agent_monitored_endpoints
+      - name: hawkular_openshift_agent_monitored_pods
+      - name: hawkular_openshift_agent_monitored_metrics

--- a/hawkular-openshift-agent/hawkular-openshift-agent.yaml
+++ b/hawkular-openshift-agent/hawkular-openshift-agent.yaml
@@ -88,29 +88,10 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: HAWKULAR_SERVER_URL
-            value: https://hawkular-metrics
-          - name: HAWKULAR_SERVER_CA_CERT_FILE
-            value: "/hawkular-metrics-certificate/hawkular-metrics-ca.certificate"
-          - name: HAWKULAR_SERVER_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: hawkular-metrics-account 
-                key: hawkular-metrics.username
-          - name: HAWKULAR_SERVER_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: hawkular-metrics-account
-                key: hawkular-metrics.password
           volumeMounts:
-          - name: hawkular-metrics-certificate
-            mountPath: "/hawkular-metrics-certificate"
           - name: hawkular-openshift-agent-configuration
             mountPath: "/hawkular-openshift-agent-configuration"
         volumes:
-        - name: hawkular-metrics-certificate
-          secret:
-            secretName: hawkular-metrics-certificate
         - name: hawkular-openshift-agent-configuration
           configMap:
             name: hawkular-openshift-agent-configuration


### PR DESCRIPTION
Deploy the agent to the 'default' project so that it works in ovs_multitenant environments.