### PR TITLE
Create a Cassandra base image so we can more easily apply patches.

### DIFF
--- a/cassandra/0001-Handle-exabyte-sized-filesystems.patch
+++ b/cassandra/0001-Handle-exabyte-sized-filesystems.patch
@@ -1,0 +1,73 @@
+From e384d0c4e877941947e64c40b8550e2c39935fa2 Mon Sep 17 00:00:00 2001
+From: mwringe <mwringe@redhat.com>
+Date: Fri, 10 Feb 2017 13:31:42 -0500
+Subject: [PATCH 1/1] Handle exabyte sized filesystems
+
+---
+ .../apache/cassandra/config/DatabaseDescriptor.java  | 20 ++++++++++++++++++--
+ src/java/org/apache/cassandra/db/Directories.java    | 10 +++++++++-
+ 2 files changed, 27 insertions(+), 3 deletions(-)
+
+diff --git a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+index baea210..7cfbc03 100644
+--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
++++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+@@ -522,8 +522,15 @@ public class DatabaseDescriptor
+             int minSize = 0;
+             try
+             {
++                // If we are dealing with a large enough filesystem, the size will overflow the long.
++                // If that is the case, set the value to the maximum value for a long
++                // See https://bugs.openjdk.java.net/browse/JDK-8162520
++                long totalSpace = guessFileStore(conf.commitlog_directory).getTotalSpace();
++                if (totalSpace < 0) {
++                    totalSpace = Long.MAX_VALUE;
++                }
+                 // use 1/4 of available space.  See discussion on #10013 and #10199
+-                minSize = Ints.checkedCast((guessFileStore(conf.commitlog_directory).getTotalSpace() / 1048576) / 4);
++                minSize = Ints.saturatedCast((totalSpace / 1048576) / 4);
+             }
+             catch (IOException e)
+             {
+@@ -571,7 +578,16 @@ public class DatabaseDescriptor
+ 
+             try
+             {
+-                dataFreeBytes += guessFileStore(datadir).getUnallocatedSpace();
++                long unallocatedSpace = guessFileStore(datadir).getUnallocatedSpace();
++                // If we are dealing with a large enough filesystem, the size will overflow the long
++                // If that is the case, set the value to the maximum value for a long
++                // See https://bugs.openjdk.java.net/browse/JDK-8162520
++                if (unallocatedSpace < 0) {
++                    unallocatedSpace = Long.MAX_VALUE;
++                }
++
++                // if there is a long overflow, set the value to Long.MAX_VALUE
++                dataFreeBytes = (dataFreeBytes + unallocatedSpace < 0) ? Long.MAX_VALUE : dataFreeBytes + unallocatedSpace;
+             }
+             catch (IOException e)
+             {
+diff --git a/src/java/org/apache/cassandra/db/Directories.java b/src/java/org/apache/cassandra/db/Directories.java
+index 68aa6be..2c96c28 100644
+--- a/src/java/org/apache/cassandra/db/Directories.java
++++ b/src/java/org/apache/cassandra/db/Directories.java
+@@ -523,7 +523,15 @@ public class Directories
+ 
+         public long getAvailableSpace()
+         {
+-            long availableSpace = location.getUsableSpace() - DatabaseDescriptor.getMinFreeSpacePerDriveInBytes();
++            long usableSpace = location.getUsableSpace();
++            // If we are dealing with a large enough filesystem, the size will overflow the long.
++            // If that is the case, set the value to the maximum value for a long
++            // See https://bugs.openjdk.java.net/browse/JDK-8162520
++            if (usableSpace < 0) {
++                usableSpace = Long.MAX_VALUE;
++            }
++
++            long availableSpace = usableSpace - DatabaseDescriptor.getMinFreeSpacePerDriveInBytes();
+             return availableSpace > 0 ? availableSpace : 0;
+         }
+ 
+-- 
+2.9.3
+

--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -36,20 +36,41 @@ ENV CASSANDRA_VERSION="3.0.9" \
 # Become the root user to be able to install and setup Cassandra under /opt
 USER root
 
-#
-RUN yum install -y -q bind-utils && \
-    yum clean all
+# Remove once https://issues.apache.org/jira/browse/CASSANDRA-13067 is fixed
+COPY 0001-Handle-exabyte-sized-filesystems.patch /tmp/
+# Remove once https://issues.apache.org/jira/browse/CASSANDRA-13067 is fixed
+RUN yum install -y -q bind-utils git ant patch && \
+    yum clean all && \
+    export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8 && \
+    export CASSANDRA_BUILD=1 && \
+    cd /tmp && \
+    git clone https://github.com/apache/cassandra && \
+    cd cassandra && \
+    git checkout cassandra-${CASSANDRA_VERSION} && \
+    patch -p1 < /tmp/0001-Handle-exabyte-sized-filesystems.patch && \
+    ant artifacts -Dbase.version=${CASSANDRA_VERSION}-${CASSANDRA_BUILD} -Drelease=true && \
+    cd /opt && \
+    cp /tmp/cassandra/build/apache-cassandra-${CASSANDRA_VERSION}-${CASSANDRA_BUILD}-bin.tar.gz . && \
+    tar xzf apache-cassandra-${CASSANDRA_VERSION}-${CASSANDRA_BUILD}-bin.tar.gz && \
+    rm apache-cassandra-${CASSANDRA_VERSION}-${CASSANDRA_BUILD}-bin.tar.gz && \
+    ln -s apache-cassandra-${CASSANDRA_VERSION}-${CASSANDRA_BUILD} apache-cassandra
 
-COPY apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz.md5 \
-     /tmp/
+
+#Uncomment the following sections once https://issues.apache.org/jira/browse/CASSANDRA-13067 is fixed
+#
+#RUN yum install -y -q bind-utils && \
+#    yum clean all
+
+#COPY apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz.md5 \
+#     /tmp/
 
 # Copy the Cassandra binary to the /opt directory
-RUN cd /opt; \
-    curl -LO https://archive.apache.org/dist/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz && \
-    if [ "$(md5sum apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz | awk '{print $1}')" != "$(cat /tmp/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz.md5)" ]; then echo "The Cassandra binary does not match the expected md5sum"; exit 1; fi && \
-    tar xzf apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz && \
-    rm apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz && \
-    ln -s apache-cassandra-$CASSANDRA_VERSION apache-cassandra
+#RUN cd /opt; \
+#    curl -LO https://archive.apache.org/dist/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz && \
+#    if [ "$(md5sum apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz | awk '{print $1}')" != "$(cat /tmp/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz.md5)" ]; then echo "The Cassandra binary does not match the expected md5sum"; exit 1; fi && \
+#    tar xzf apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz && \
+#    rm apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz && \
+#    ln -s apache-cassandra-$CASSANDRA_VERSION apache-cassandra
 
 # Copy our version of the cassandra configuration file over to the filesystem
 COPY cassandra.yaml.template \


### PR DESCRIPTION
Creates a separate cassandra-base image which will build Cassandra from source.

Apply patch to allow Cassandra to run on EFS (https://bugzilla.redhat.com/show_bug.cgi?id=1418748)