### PR TITLE
Change Heapster labelToTenant 

### DIFF
--- a/deployer/templates/heapster.yaml
+++ b/deployer/templates/heapster.yaml
@@ -85,7 +85,7 @@ objects:
           - "--wrapper.allowed_users_file=/secrets/heapster.allowed-users"
           - "--wrapper.endpoint_check=https://hawkular-metrics:443/hawkular/metrics/status"
           - "--source=kubernetes.summary_api:${MASTER_URL}?useServiceAccount=true&kubeletHttps=true&kubeletPort=10250"
-          - "--sink=hawkular:https://hawkular-metrics:443?tenant=_system&labelToTenant=pod_namespace&labelNodeId=${NODE_ID}&caCert=/hawkular-cert/hawkular-metrics-ca.certificate&user=%username%&pass=%password%&filter=label(container_name:^system.slice.*|^user.slice)"
+          - "--sink=hawkular:https://hawkular-metrics:443?tenant=_system&labelToTenant=namespace_name&labelNodeId=${NODE_ID}&caCert=/hawkular-cert/hawkular-metrics-ca.certificate&user=%username%&pass=%password%&filter=label(container_name:^system.slice.*|^user.slice)"
           - "--tls_cert=/heapster-certs/tls.crt"
           - "--tls_key=/heapster-certs/tls.key"
           - "--tls_client_ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"


### PR DESCRIPTION
Changes labelToTenant from pod_namespace (deprecated) to namespace_name. This does not change old behavior:

https://github.com/kubernetes/heapster/blob/b0a73e1c64a2787242368b55efdb542a632ef726/metrics/processors/pod_based_enricher.go

As the same namespace modifier is used in the enriching process, but it fixes the bug in namespace handling:

https://github.com/kubernetes/heapster/blob/96d9dbf9ee20c200bb7703a8dff0b5ea7c1d1ba1/metrics/processors/namespace_aggregator.go#L60

As pod_namespace is not used there, but namespace_name is enriched there.