### PR TITLE
- "alpha" is obsoleted in favor of "beta" in Persistant volume claim definition 

### DIFF
--- a/deployer/templates/hawkular-cassandra-node-dynamic-pv.yaml
+++ b/deployer/templates/hawkular-cassandra-node-dynamic-pv.yaml
@@ -36,7 +36,7 @@ objects:
     labels:
       metrics-infra: hawkular-cassandra
     annotations:
-      volume.alpha.kubernetes.io/storage-class: "dynamic"
+      volume.beta.kubernetes.io/storage-class: "dynamic"
   spec:
     accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
- "alpha" is obsoleted in favour of "beta" in Persistent Volume Claim definition 
more about it in documentation : 

http://blog.kubernetes.io/2016/10/dynamic-provisioning-and-storage-in-kubernetes.html

Signed-off-by: Elvir Kuric <elvirkuric@gmail.com>

