### PR TITLE
fix openshift/origin#15920. Default uptime to 0 if string

### DIFF
--- a/hawkular-metrics/hawkular-metrics-liveness.py
+++ b/hawkular-metrics/hawkular-metrics-liveness.py
@@ -26,6 +26,8 @@ statusURL = "http://localhost:" + hawkularEndpointPort  + "/hawkular/metrics/sta
 timeout = os.environ.get("STARTUP_TIMEOUT", 500)
 
 uptime = os.popen("ps -eo comm,etimes | grep -i standalone.sh | awk '{print $2}'").read()
+if type(uptime) == str:
+  uptime = 0
 
 try:
   # need to set a timeout, the default is to never timeout.
@@ -33,7 +35,7 @@ try:
   statusCode = response.getcode();
   # if the status is 200, then continue
   if (statusCode == 200):
-    responseHTML = response.read() 
+    responseHTML = response.read()
     jsonResponse = json.loads(responseHTML)
     # if the metrics service is started then we are good
     if (jsonResponse["MetricsService"] == "STARTED"):


### PR DESCRIPTION
This PR fixes openshift/origin#15920:

```
Traceback (most recent call last):
  File "/opt/hawkular/scripts/hawkular-metrics-liveness.py", line 48, in <module>
    if int(uptime) < int(timeout):
ValueError: invalid literal for int() with base 10: ''
```
I assume for the case where the process does not exist and returns empty string