### PR TITLE
[BZ 1473013] disable commit log compression

### DIFF
--- a/cassandra/cassandra.yaml.template
+++ b/cassandra/cassandra.yaml.template
@@ -324,8 +324,8 @@ commitlog_segment_size_in_mb: 32
 # Compression to apply to the commit log. If omitted, the commit log
 # will be written uncompressed.  LZ4, Snappy, and Deflate compressors
 # are supported.
-commitlog_compression:
-   - class_name: LZ4Compressor
+#commitlog_compression:
+#   - class_name: LZ4Compressor
 #     parameters:
 #         -
 


### PR DESCRIPTION
We have been using commit log compression, but other commit log
settings in cassandra.yaml assume compression is disabled. I think
this is why we have run into problems with running out of memory
during commit log replay.

Compression was turned on as an optimization. The safest course
at least for now is to simply revert back to out of the box
settings.