### PR TITLE
Add support for building dev images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ deployer/_secret
 *~
 .idea
 *.iml
+hawkular-metrics/dev/hawkular-metrics.*

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -10,6 +10,8 @@ source_root=$(dirname "${0}")/..
 prefix="openshift/origin-"
 version="latest"
 verbose=false
+dev_build=false
+build_args=""
 options=""
 help=false
 
@@ -27,6 +29,9 @@ do
         ;;
       --verbose)
         verbose=true
+        ;;
+     --dev)
+        dev_build=true
         ;;
      --help)
         help=true
@@ -56,10 +61,17 @@ if [ "$help" = true ]; then
   echo "  --verbose"
   echo "  Enables printing of the commands as they run."
   echo
+  echo "  --dev"
+  echo "  Specifies that this is a dev build."
+  echo
   echo "  --help"
   echo "  Prints this help message"
   echo
   exit 0
+fi
+
+if [ "$dev_build" = true ]; then
+  build_args="--build-arg DEV_BUILD=true"
 fi
 
 if [ "$verbose" = true ]; then
@@ -73,7 +85,7 @@ for component in deployer heapster hawkular-metrics cassandra; do
   echo
   echo
   echo "--- Building component '$comp_path' with docker tag '$docker_tag' ---"
-  docker build ${options} -t $docker_tag       $comp_path
+  docker build ${options} ${build_args} -t $docker_tag $comp_path
   BUILD_ENDTIME=$(date +%s); echo "--- $docker_tag took $(($BUILD_ENDTIME - $BUILD_STARTTIME)) seconds ---"
   echo
   echo

--- a/hawkular-metrics/Dockerfile
+++ b/hawkular-metrics/Dockerfile
@@ -46,8 +46,6 @@ COPY prometheus.yaml $JBOSS_HOME/standalone/configuration/prometheus.yaml
 RUN mkdir /tmp/hawkular
 COPY dev/* /tmp/hawkular/
 
-RUN ls -l /tmp/hawkular
-
 # Get and copy the hawkular metrics war to the deployment directory
 RUN cd $JBOSS_HOME/standalone/deployments/ && \
     if [ ${DEV_BUILD} = "true" ] && [ -s /tmp/hawkular/hawkular-metrics.ear ]; then mv /tmp/hawkular/hawkular-metrics.ear .; rm -rf /tmp/hawkular; else curl -Lo hawkular-metrics.ear https://origin-repository.jboss.org/nexus/service/local/artifact/maven/content?r=public\&g=org.hawkular.metrics\&a=hawkular-metrics-openshift-dist\&e=ear\&v=${HAWKULAR_METRICS_VERSION}; fi

--- a/hawkular-metrics/Dockerfile
+++ b/hawkular-metrics/Dockerfile
@@ -33,6 +33,8 @@ ENV HAWKULAR_METRICS_ENDPOINT_PORT="8080" \
     PATH=$PATH:$HAWKULAR_METRICS_SCRIPT_DIRECTORY \
     JAVA_OPTS_APPEND="-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heapdump"
 
+ARG DEV_BUILD="false"
+
 # The http and https ports
 EXPOSE 8080 8444
 
@@ -41,9 +43,14 @@ RUN cd $JBOSS_HOME/bin && \
     curl -Lo $JBOSS_HOME/bin/jmx_prometheus_javaagent.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.9/jmx_prometheus_javaagent-0.9.jar
 COPY prometheus.yaml $JBOSS_HOME/standalone/configuration/prometheus.yaml
 
+RUN mkdir /tmp/hawkular
+COPY dev/* /tmp/hawkular/
+
+RUN ls -l /tmp/hawkular
+
 # Get and copy the hawkular metrics war to the deployment directory
 RUN cd $JBOSS_HOME/standalone/deployments/ && \
-    curl -Lo hawkular-metrics.ear https://origin-repository.jboss.org/nexus/service/local/artifact/maven/content?r=public\&g=org.hawkular.metrics\&a=hawkular-metrics-openshift-dist\&e=ear\&v=${HAWKULAR_METRICS_VERSION}
+    if [ ${DEV_BUILD} = "true" ] && [ -s /tmp/hawkular/hawkular-metrics.ear ]; then mv /tmp/hawkular/hawkular-metrics.ear .; rm -rf /tmp/hawkular; else curl -Lo hawkular-metrics.ear https://origin-repository.jboss.org/nexus/service/local/artifact/maven/content?r=public\&g=org.hawkular.metrics\&a=hawkular-metrics-openshift-dist\&e=ear\&v=${HAWKULAR_METRICS_VERSION}; fi
 
 # Add in the JGroups Kubernetes clustering module
 RUN mkdir -p $JBOSS_HOME/modules/system/layers/base/org/jgroups/kubernetes/main && \

--- a/hawkular-metrics/dev/README.adoc
+++ b/hawkular-metrics/dev/README.adoc
@@ -1,0 +1,5 @@
+== About
+This directory exists in order to support building development images. If `build-images.sh`
+is executed with `--dev` and if hawkular-metrics.ear exists in this directory, then the
+hawkular-metrics image will be built using the local copy of the EAR instead of downloading
+a released artifact from the JBoss nexus repo.


### PR DESCRIPTION
To date there has been no support for building images with locally built
versions of hawkular-metrics. The docker build only produces images that
include released versions of hawkular-metrics that get downloaded from
the JBoss nexus repo. This makes it awkward and error prone to test
changes that have not been released. I have resorted to modifying the
Dockerfile to copy a locally built hawkular-metrics EAR.

This commit adds support for building images with locally built versions
with a few small changes. The build-images.sh script has a --dev option
to indicate a dev build. If the dev flag is set and if a
hawkular-metrics.ear file exists in the hawkular-metrics/dev directory,
then it will be used. The hawkular-metrics version environment variable
will be ignored.