### PR TITLE
[BZ 1567251] Disable auto snapshots and env var for taking snapshots

### DIFF
--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -31,7 +31,8 @@ ENV CASSANDRA_VERSION="3.0.15" \
     CASSANDRA_HOME="/opt/apache-cassandra" \
     HOME="/home/cassandra" \
     PATH="/opt/apache-cassandra/bin:$PATH" \
-    CASSANDRA_NODES_SERVICE_NAME="hawkular-cassandra-nodes"
+    CASSANDRA_NODES_SERVICE_NAME="hawkular-cassandra-nodes" \
+    TAKE_SNAPSHOT="false"
 
 # Become the root user to be able to install and setup Cassandra under /opt
 USER root

--- a/cassandra/cassandra.yaml.template
+++ b/cassandra/cassandra.yaml.template
@@ -633,7 +633,7 @@ snapshot_before_compaction: false
 # or dropping of column families. The STRONGLY advised default of true 
 # should be used to provide data safety. If you set this flag to false, you will
 # lose data on truncation or drop.
-auto_snapshot: true
+auto_snapshot: false
 
 # When executing a scan, within or across a partition, we need to keep the
 # tombstones seen in memory so we can return them to the coordinator, which


### PR DESCRIPTION
Disabling auto snapshots for Cassandra by default because 1) we do not
have a mechanism for snapshots and because 2) the temp data temp tables
introduced in OpenShift 3.7 generate a lot of snapshots that can eat up
disk space in a hurry.

This commit introduces a new environment variable, TAKE_SNAPSHOT, which
if set to "true" will cause a snapshot to be generated in the
cassandra-poststart.sh script which is run from the postStart lifecycle
hook. The snapshop name uses a default value of a timestamp.